### PR TITLE
use featuresIn to select features for editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,6 @@
   },
   "dependencies": {
     "hat": "0.0.3",
-    "ramda": "^0.17.1",
-    "turf-bbox-polygon": "^1.0.1",
-    "turf-intersect": "^1.4.2"
+    "ramda": "^0.17.1"
   }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -1,8 +1,5 @@
 'use strict';
 
-import bboxPoly from 'turf-bbox-polygon';
-import intersect from 'turf-intersect';
-
 /**
  * A store for keeping track of versions of drawings
  *
@@ -80,22 +77,25 @@ export default class Store {
    * @param {Object} p2 - the pixel coordinates of the second point
    */
   editFeaturesIn(p1, p2) {
-    p1 = this._map.unproject([ p1.x, p1.y ]);
-    p2 = this._map.unproject([ p2.x, p2.y ]);
-    var latMin = p1.lat < p2.lat ? p1.lat : p2.lat;
-    var lngMin = p1.lng < p2.lng ? p1.lng : p2.lng;
-    var latMax = p1.lat > p2.lat ? p1.lat : p2.lat;
-    var lngMax = p1.lng > p2.lng ? p1.lng : p2.lng;
-    var bbox = bboxPoly([ lngMin, latMin, lngMax, latMax ]);
-    var inside = [];
-    for (var id in this._features) {
-      if (intersect(this._features[id].toGeoJSON(), bbox)) {
-        inside.push(id);
-      }
-    }
-    for (var i = 0; i < inside.length; i++) {
-      this.edit(inside[i]);
-    }
+    var xMin = p1.x < p2.x ? p1.x : p2.x;
+    var yMin = p1.y < p2.y ? p1.y : p2.y;
+    var xMax = p1.x > p2.x ? p1.x : p2.x;
+    var yMax = p1.y > p2.y ? p1.y : p2.y;
+    var bbox = [ [xMin, yMin], [xMax, yMax] ];
+    var drawLayers = [ 'gl-draw-polygon', 'gl-draw-line', 'gl-draw-point' ];
+    this._map.featuresIn(bbox, { layers: drawLayers, type: 'vector' }, (err, features) => {
+      if (err) throw err;
+      // featuresIn can return the same feature multiple times
+      // handle this with a reduce
+      features.reduce((set, feature) => {
+        var id = feature.properties.drawId;
+        if (this._features[id] && set[id] === undefined) {
+          set[id] = 1;
+          this.edit(id);
+        }
+        return set;
+      }, {});
+    });
   }
 
   _render() {


### PR DESCRIPTION
This decreases the size of bundled versions of mapbox-gl-draw by removing turf-intersect and opting for the maps default featureIn selector.

@kelvinabrokwa or @tmcw for the review