### PR TITLE
Hide internal events from end user and standardize external events

### DIFF
--- a/API.md
+++ b/API.md
@@ -173,44 +173,12 @@ Draw
 
 ## Events
 
-Draw fires off a number of events on draw and edit actions.
+Draw fires off a number of events on draw and edit actions. All of these events are name spaced `draw` inside of the mapboxgl event emitter.
 
+#### draw.set
 
-####`drawing.start`
+This is fired every time a feature is commited via escape or the double click. The payload is an object with the `mapbox-gl-draw` id and the geojson representation of the feature.
 
-Fired when a drawing is started. Passes an object with the the feature type to the callback (`{ featureType: <String> }`). Note that these are mapbox-gl-draw feature type, one of `point`, `line`, `polygon`, `square`.
+#### draw.delete
 
-Example:
-
-```
-map.on('drawing.start', function(e) {
-  alert('Started drawing a ', e.featureType);
-});
-```
-
----
-####`drawing.end`
-
-Fired when a drawing is finished. Passes an object with the feature type and the geojson geometry to the callback.
-
-Example:
-
-```
-map.on('drawing.end', function(e) {
-  alert('Finished drawing a ', e.featureType, 'with the coordintes', JSON.stringify(e.geometry.coordinates));
-});
-```
-
----
-
-####`edit.new`
-
-Fired while editting when a new edit is made. Passes an object with the new geometry and its drawId to the callback.
-
-Example:
-
-```
-map.on('edit.new', function(e) {
-  alert('new edit on', e.id, '->', JSON.stringify(e.geojson));
-});
-```
+This is fired every time a feature is deleted inside of `mapbox-gl-draw`. The payload is an object with the `mapbox-gl-draw` id of the feature that was deleted and the geojson representation of the feature just before it was deleted.

--- a/src/draw.js
+++ b/src/draw.js
@@ -19,6 +19,8 @@ import Point from './geometries/point';
 import Square from './geometries/square';
 import Polygon from './geometries/polygon';
 
+import InternalEvents from './internal_events';
+
 /**
  * Draw plugin for Mapbox GL JS
  *
@@ -440,12 +442,12 @@ export default class Draw extends API {
    */
   _setEventListeners() {
 
-    this._map.on('drawing.new.update', e => {
+    InternalEvents.on('drawing.new.update', e => {
       this._map.getSource('drawing').setData(e.geojson);
     });
 
     // clear the drawing layer after a drawing is done
-    this._map.on('drawing.end', e => {
+    InternalEvents.on('drawing.end', e => {
       this._map.getSource('drawing').setData({
         type: 'FeatureCollection',
         features: []
@@ -458,11 +460,11 @@ export default class Draw extends API {
         this.markerCtrl ].forEach(ctrl => { if (ctrl) ctrl.classList.remove('active'); });
     });
 
-    this._map.on('edit.feature.update', e => {
+    InternalEvents.on('edit.feature.update', e => {
       this._map.getSource('edit').setData(e.geojson);
     });
 
-    this._map.on('draw.feature.update', e => {
+    InternalEvents.on('draw.feature.update', e => {
       this._map.getSource('draw').setData(e.geojson);
     });
 
@@ -489,7 +491,7 @@ export default class Draw extends API {
       });
     });
 
-    this._map.on('drawing.cancel', e => {
+    InternalEvents.on('drawing.cancel', e => {
       this._store.unset(e.drawId);
     });
 

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import InternalEvents from './internal_events';
+
 /**
  * A store for keeping track of in progress
  * feature edits before they written into history
@@ -18,9 +20,9 @@ export default class EditStore {
 
     this.drawStore = null;
 
-    this._map.on('edit.new', () => { this._render(); });
-    this._map.on('finish.edit', () => { this._render(); });
-    this._map.on('edit.end', e => { this.endEdit(e.geometry.drawId); });
+    InternalEvents.on('edit.new', () => { this._render(); });
+    InternalEvents.on('finish.edit', () => { this._render(); });
+    InternalEvents.on('edit.end', e => { this.endEdit(e.geometry.drawId); });
   }
 
   setDrawStore(drawStore) {
@@ -139,7 +141,7 @@ export default class EditStore {
   _render() {
     var geom = this.getAllGeoJSON();
     geom.features = geom.features.concat(this._addVertices(), this._addMidpoints());
-    this._map.fire('edit.feature.update', {
+    InternalEvents.emit('edit.feature.update', {
       geojson: geom
     });
   }

--- a/src/geometries/geometry.js
+++ b/src/geometries/geometry.js
@@ -2,6 +2,7 @@
 
 import hat from 'hat';
 import { translate } from '../util';
+import InternalEvents from '../internal_events';
 
 /**
  * Base Geometry class which other geometries extend
@@ -82,7 +83,7 @@ export default class Geometry {
    */
   _finishDrawing(type) {
     this._map.getContainer().removeEventListener('keyup', this.onKeyUp);
-    this._map.fire('drawing.end', {
+    InternalEvents.emit('drawing.end', {
       geometry: this,
       featureType: type
     });
@@ -96,7 +97,7 @@ export default class Geometry {
     }
     if (e.keyCode === ESCAPE) {
       this._completeDraw();
-      this._map.fire('drawing.cancel', { drawId: this.drawId });
+      InternalEvents.emit('drawing.cancel', { drawId: this.drawId });
     }
   }
 
@@ -115,14 +116,14 @@ export default class Geometry {
     var translatedGeom = translate(this.initGeom, init, curr, this._map);
     this.coordinates = translatedGeom.geometry.coordinates;
 
-    this._map.fire('edit.new', {
+    InternalEvents.emit('edit.new', {
       id: this.drawId,
       geojson: this.toGeoJSON()
     });
   }
 
   _renderDrawProgress() {
-    this._map.fire('drawing.new.update', {
+    InternalEvents.emit('drawing.new.update', {
       geojson: this.toGeoJSON()
     });
   }

--- a/src/geometries/line.js
+++ b/src/geometries/line.js
@@ -2,6 +2,7 @@
 
 import Geometry from './geometry';
 import { translatePoint, DOM } from '../util';
+import InternalEvents from '../internal_events';
 
 /**
  * Line geometry class
@@ -34,7 +35,7 @@ export default class Line extends Geometry {
 
   startDraw() {
     this._map.getContainer().addEventListener('keyup', this.onKeyUp);
-    this._map.fire('drawing.start', { featureType: 'line' });
+    InternalEvents.emit('drawing.start', { featureType: 'line' });
     this._map.getContainer().classList.add('mapboxgl-draw-activated');
     this._map.on('click', this.addPoint);
     this._map.on('dblclick', this.completeDraw);
@@ -92,7 +93,7 @@ export default class Line extends Geometry {
 
     this.coordinates[idx] = newPoint;
 
-    this._map.fire('edit.new', {
+    InternalEvents.emit('edit.new', {
       id: this.drawId,
       geojson: this.toGeoJSON()
     });
@@ -108,7 +109,7 @@ export default class Line extends Geometry {
     coords = this._map.unproject(coords);
     this.coordinates.splice(idx, 0, [ coords.lng, coords.lat ]);
 
-    this._map.fire('edit.new');
+    InternalEvents.emit('edit.new');
   }
 
 }

--- a/src/geometries/point.js
+++ b/src/geometries/point.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import Geometry from './geometry';
+import InternalEvents from '../internal_events';
 
 /**
  * Point geometry class
@@ -27,7 +28,7 @@ export default class Point extends Geometry {
   }
 
   startDraw() {
-    this._map.fire('drawing.start', { featureType: 'point' });
+    InternalEvents.emit('drawing.start', { featureType: 'point' });
     this._map.getContainer().classList.add('mapboxgl-draw-activated');
     this._map.on('click', this.completeDraw);
   }

--- a/src/geometries/polygon.js
+++ b/src/geometries/polygon.js
@@ -2,6 +2,7 @@
 
 import Geometry from './geometry';
 import { translatePoint, DOM } from '../util';
+import InternalEvents from '../internal_events';
 
 /**
  * Polygon geometry class
@@ -32,7 +33,7 @@ export default class Polygon extends Geometry {
 
   startDraw() {
     this._map.getContainer().addEventListener('keyup', this.onKeyUp);
-    this._map.fire('drawing.start', { featureType: 'polygon' });
+    InternalEvents.emit('drawing.start', { featureType: 'polygon' });
     this._map.getContainer().classList.add('mapboxgl-draw-activated');
     this._map.on('click', this.addVertex);
     this._map.on('dblclick', this.completeDraw);
@@ -56,7 +57,7 @@ export default class Polygon extends Geometry {
       this.coordinates[0].push(this.first);
     }
 
-    this._map.fire('edit.new', {
+    InternalEvents.emit('edit.new', {
       id: this.drawId,
       geojson: this.toGeoJSON()
     });
@@ -106,7 +107,7 @@ export default class Polygon extends Geometry {
     if (idx === 0)
       this.coordinates[0][this.coordinates[0].length - 1] = newPoint;
 
-    this._map.fire('edit.new', {
+    InternalEvents.emit('edit.new', {
       id: this.drawId,
       geojson: this.toGeoJSON()
     });
@@ -123,7 +124,7 @@ export default class Polygon extends Geometry {
     coords = this._map.unproject(coords);
     this.coordinates[0].splice(idx, 0, [ coords.lng, coords.lat ]);
 
-    this._map.fire('edit.new', {
+    InternalEvents.emit('edit.new', {
       id: this.drawId,
       geojson: this.toGeoJSON()
     });

--- a/src/geometries/square.js
+++ b/src/geometries/square.js
@@ -2,6 +2,7 @@
 
 import Geometry from './geometry';
 import { translatePoint, DOM } from '../util';
+import InternalEvents from '../internal_events';
 
 /**
  * Square geometry class
@@ -31,7 +32,7 @@ export default class Square extends Geometry {
 
   startDraw() {
     this._map.getContainer().addEventListener('keyup', this.onKeyUp);
-    this._map.fire('drawing.start', { featureType: 'square' });
+    InternalEvents.emit('drawing.start', { featureType: 'square' });
     this._map.getContainer().classList.add('mapboxgl-draw-activated');
     this._map.getContainer().addEventListener('mousedown', this.onMouseDown, true);
   }
@@ -124,7 +125,7 @@ export default class Square extends Geometry {
     // always reset last point to equal the first point
     this.coordinates[0][4] = this.coordinates[0][0];
 
-    this._map.fire('edit.new', {
+    InternalEvents.emit('edit.new', {
       id: this.drawId,
       geojson: this.toGeoJSON()
     });

--- a/src/internal_events.js
+++ b/src/internal_events.js
@@ -1,0 +1,5 @@
+// TODO: Remove the need for internal event handling
+// by more clearly and explicitly defining the relationship
+// between geometries, draw.js and the stores.
+
+export default new (require('events').EventEmitter);


### PR DESCRIPTION
Currently gl-draw uses the public mapbox-gl-js event emitter for its own internal state management. This has the nice benefit of giving end users a way to connect into the gl-draw life cycle, but it also makes it hard to create good internal updates as external and internal api contacts are tightly bound. This PR separates these concerns and starts to set standards around external event naming and payload content. 

**This is a breaking change.** As we are still in 0.*.* range, this will not mean a major bump, but I want to make sure anyone who is watching  this today is aware of the direction @kelvinabrokwa and I are looking to go. I also didn't recreate all of `0.0.2`s external events. If there are no major complaints, my goal is to merge this tomorrow as `0.1.0` so that pacakge.json files that used the ^ operator.

Closes #138 

/cc @drewbo @tmcw @edenh 