### PR TITLE
Add edit selection events

### DIFF
--- a/API.md
+++ b/API.md
@@ -177,8 +177,16 @@ Draw fires off a number of events on draw and edit actions. All of these events 
 
 #### draw.set
 
-This is fired every time a feature is commited via escape or the double click. The payload is an object with the `mapbox-gl-draw` id and the geojson representation of the feature.
+This is fired every time a feature is commited via escape or the double click. The payload is an object with the `mapbox-gl-draw` feature id and the geojson representation of the feature.
 
 #### draw.delete
 
-This is fired every time a feature is deleted inside of `mapbox-gl-draw`. The payload is an object with the `mapbox-gl-draw` id of the feature that was deleted and the geojson representation of the feature just before it was deleted.
+This is fired every time a feature is deleted inside of `mapbox-gl-draw`. The payload is an object with the `mapbox-gl-draw` feature id of the feature that was deleted and the geojson representation of the feature just before it was deleted.
+
+#### draw.edit.start
+
+Fired every time a feature is selected for edit. The payload is an object with the `mapbox-gl-draw` feature id and the geojson representation of the feature.
+
+#### draw.edit.end
+
+Fired every time a feature is unselected for edit. The payload is an object with the `mapbox-gl-draw` feature id.

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -37,6 +37,9 @@ export default class EditStore {
   finish() {
     for (var id in this._features) {
       this._drawStore.set(this._features[id]);
+      this._map.fire('draw.edit.end', {
+        id
+      });
       delete this._features[id];
     }
     this._render();

--- a/src/store.js
+++ b/src/store.js
@@ -68,7 +68,7 @@ export default class Store {
   unset(id) {
     if (this._features[id]) {
       this._map.fire('draw.delete', {
-        id: id,
+        id,
         geojson: this._features[id].geojson
       });
     }
@@ -82,6 +82,10 @@ export default class Store {
    */
   edit(id) {
     this._editStore.set(this._features[id]);
+    this._map.fire('draw.edit.start', {
+      id,
+      geojson: this._features[id].geojson
+    });
     delete this._features[id];
     this._render();
   }


### PR DESCRIPTION
Adds `draw.edit.start` and `draw.edit.end` events that fire when a feature is selected/deselected.

Closes #139 

cc @mcwhittemore 