### PR TITLE
`draw.delete` should be emitted after the feature is removed from the store

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "babel-preset-es2015": "^6.3.13",
     "hat": "0.0.3",
+    "mapbox-gl": "^0.14.1",
     "ramda": "^0.17.1"
   }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -63,13 +63,14 @@ export default class Store {
    */
   delete(id) {
     if (this._features[id]) {
-      if (this._features[id].created) {
+      var geojson = this._features[id].created ? this._features[id].toGeoJSON() : null;
+      delete this._features[id];
+      if (geojson) {
         this._map.fire('draw.delete', {
           id: id,
-          geojson: this._features[id].toGeoJSON()
+          geojson: geojson
         });
       }
-      delete this._features[id];
       this._render();
     }
   }


### PR DESCRIPTION
This stops code like

```
map.on('draw.delete', function(geojson) { Draw.deselect(geojson.id); });
```

from emitting the `draw.set` event.