### PR TITLE
Update mapbox-gl peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "uglify-js": "^2.4.23"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.13.1 || ^0.14.0"
+    "mapbox-gl": "^0.13.1 || ^0.14.0 || ^0.15.0"
   },
   "dependencies": {
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
Maybe a little overkill at this point but don't want to leave behind `0.13` yet