### PR TITLE
adjust how token and initial map view are set to be more like mapbox-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Also include [mapbox-gl-draw.css](https://github.com/mapbox/mapbox-gl-draw/blob/
 ```
 
 ### Usage
+Either adjust this `open http://localhost:9966/debug/?access_token=<token>#13/37.76/-122.42` or use something like:
 
 ```js
 mapboxgl.accessToken = 'YOUR_ACCESS_TOKEN';

--- a/debug/index.html
+++ b/debug/index.html
@@ -47,7 +47,7 @@
 <script src='../dist/mapbox-gl-draw.js'></script>
 <script type='text/javascript'>
 	// making run more like github.com/mapbox/mapbox-gl-js
-	//eg http://127.0.0.1:9966/debug/?access_token=<the-token>##13/37.76/-122.42
+	//eg http://127.0.0.1:9966/debug/?access_token=<the-token>#13/37.76/-122.42
 	var args = location.search.replace(/^\?/,'').split('&').reduce(function(o, param){ var keyvalue=param.split('='); o[keyvalue[0]] = keyvalue[1]; return o; }, {});
 	mapboxgl.accessToken = args.access_token;
 	// could work this further but going off the above example

--- a/debug/index.html
+++ b/debug/index.html
@@ -46,12 +46,27 @@
 <script src='../node_modules/mapbox-gl/dist/mapbox-gl.js'></script>
 <script src='../dist/mapbox-gl-draw.js'></script>
 <script type='text/javascript'>
-  mapboxgl.accessToken = localStorage.accessToken;
+	// making run more like github.com/mapbox/mapbox-gl-js
+	//eg http://127.0.0.1:9966/debug/?access_token=<the-token>##13/37.76/-122.42
+	var args = location.search.replace(/^\?/,'').split('&').reduce(function(o, param){ var keyvalue=param.split('='); o[keyvalue[0]] = keyvalue[1]; return o; }, {});
+	mapboxgl.accessToken = args.access_token;
+	// could work this further but going off the above example
+	location.hash.replace(/^#/,'').split('/').reduce(function(args, val, i, hash){
+		switch(i){
+		case 0: args.zoom = val; break;
+		case 1: args.latitude = val; break;
+		case 2:
+			args.longitude = val;
+			if(args.latitude) args.latlng = [val, args.latitude];
+		break;
+		};
+		return args;
+	}, args);
 
   var map = new mapboxgl.Map({
     container: 'map',
-    zoom: 1,
-    center: [0, 0],
+    zoom: args.zoom || 1,
+    center: args.latlng || [0, 0],
     style: 'mapbox://styles/mapbox/streets-v8'
   });
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "babel-eslint": "4.1.7",
     "babel-register": "^6.5.2",
+    "babelify": "^7.2.0",
     "bistre": "^1.0.1",
     "budo": "^4.0.0",
     "eslint": "^0.21.2",


### PR DESCRIPTION
…gl-js

addresses: https://github.com/mapbox/mapbox-gl-draw/issues/253 which allows urls to pass token and initial zoom/latitude/longitude like `http://localhost:9966/debug/?access_token=<token>#zoom/latitude/longitude`
all tests pass (my local `npm test` output):
```1..65
# tests 65
# pass  65

# ok
```

also fixes missing dev dependency