### PR TITLE
Fix for issue when you drag a shape and instead of a shape map is dragged

### DIFF
--- a/src/draw_events.js
+++ b/src/draw_events.js
@@ -108,7 +108,9 @@ export default function(ctx) {
     },
     onMouseMove: function(e) {
       if (isMouseDown) {
-        featuresAtProgress && e.originalEvent.stopPropagation();
+        if (featuresAtProgress) {
+          e.originalEvent.stopPropagation();
+        }
         return api.onMouseDrag(e);
       }
       else if (newFeature) {

--- a/src/draw_events.js
+++ b/src/draw_events.js
@@ -16,6 +16,7 @@ export default function(ctx) {
   var newFeature = null;
   var activeVertex = null;
   var activeDrawId = null;
+  var featuresAtProgress = false;
 
   var cleanupNewFeatureIfNeeded = function() {
      if (newFeature.created) {
@@ -52,6 +53,7 @@ export default function(ctx) {
         var drawIds = ctx._store.getSelectedIds();
         if (newFeature === null && drawIds.length > 0) {
           var coords = DOM.mousePos(e, ctx._map._container);
+          featuresAtProgress = true;
           ctx._map.featuresAt([coords.x, coords.y], { radius: 20 }, (err, features) => {
             if(err) throw err;
             features = features.filter(feature => drawIds.indexOf(feature.properties.drawId || feature.properties.parent) > -1);
@@ -70,6 +72,7 @@ export default function(ctx) {
                 activeDrawId = R.find(feat => feat.properties.drawId)(features).properties.drawId;
               }
             }
+            featuresAtProgress = false;
           });
         }
       }
@@ -104,7 +107,8 @@ export default function(ctx) {
       dragStartPoint = null;
     },
     onMouseMove: function(e) {
-      if(isMouseDown) {
+      if (isMouseDown) {
+        featuresAtProgress && e.originalEvent.stopPropagation();
         return api.onMouseDrag(e);
       }
       else if (newFeature) {


### PR DESCRIPTION
Hi guys,

I've found a serious issue while was working with this plugin. Let me try to explain what I mean. 

So, I place a shape on a map and make it `interactive: true` to always have it in editable state. And when I try to move shape on a map (the cycle is: mouse down on the shape -> move mouse -> mouse up) sometimes it works ok, but sometimes I drag the map itself instead of dragging the shape. 

I started investigate and that's what I found: when we receive `mouseDrag` event - we check if there is `activeDrawId` here: https://github.com/mapbox/mapbox-gl-draw/blob/dca6a21050f01995c61c80d3eaacaabc4eebc863/src%2Fdraw_events.js#L125. And if there is - we stop propagating event to move the shape (and not move the map). But the issue is that we set this  `activeDrawId` in handler for `mouseDown` event in asynchronous callback for 'mapbox.featruresAt' method:  https://github.com/mapbox/mapbox-gl-draw/blob/dca6a21050f01995c61c80d3eaacaabc4eebc863/src%2Fdraw_events.js#L70

Since it asynchronous, what happens sometimes: we receive `mouseDown` event and then immediately receive `mouseDrag` event. And checking for `if (activeDrawId)` is false because `featuresAt` is asynchronous and wasn't finished yet. And then we ignore dragging event and as a result - user drags map, not shape.

The flow is like here:
-> received `mouseDown` event
-> call for `mapbox.featruresAt`
-> received mouseDrag event
-> check for `activeDrawId` - false - ignore `mouseDrag` event
-> asynchronous callback `mapbox.featruresAt` is called
-> set `activeDrawId`

In this PR I made a quick fix for this issue. May be it's not best way to resolve this issue, but it works for me.