### PR TITLE
Fix draw.changed event payload to return only changed features

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -53,14 +53,13 @@ module.exports = function render() {
     var changed = [];
 
     this.featureIds.forEach((id) => {
-      let featureInternal = this.features[id].internal(mode);
+      let feature = this.features[id];
+      let featureInternal = feature.internal(mode);
       var coords = JSON.stringify(featureInternal.geometry.coordinates);
 
-      if (this.ctx.store.needsUpdate(featureInternal)) {
+      if (feature.isValid() && this.ctx.store.needsUpdate(feature.toGeoJSON())) {
         this.featureHistory[id] = coords;
-        if (this.features[id].isValid()) {
-          changed.push(this.features[id].toGeoJSON());
-        }
+        changed.push(feature.toGeoJSON());
       }
 
       this.ctx.events.currentModeRender(featureInternal, pusher);


### PR DESCRIPTION
I noticed that the `draw.changed` event would return all of the existing features in the payload. This update fixes the behavior so it will only return the feature that was changed.