### PR TITLE
fix custom styling

### DIFF
--- a/API.md
+++ b/API.md
@@ -25,7 +25,7 @@ drawing | boolean | The ability to draw and delete features - default: `true`
 keybindings | boolean | Keyboard shortcuts for drawing - default: `true`
 displayControlsDefault | boolean | Sets default value for the control keys in the control option - default `true`
 controls | Object | Lets you hide or show individual controls. See `displayControlsDefault` for default. Available options are: point, line, polygon and trash.
-style | Object | An array of style objects. By default draw provides a style for you. To override this see [Styling Draw](#styling-draw) further down.
+styles | Array | An array of style objects. By default draw provides a style for you. To override this see [Styling Draw](#styling-draw) further down.
 
 ## API Methods
 
@@ -227,6 +227,8 @@ This is fired every time a feature is unselected in the default mode. The payloa
 Draw is styled by the [Mapbox GL Style Spec](https://www.mapbox.com/mapbox-gl-style-spec/) with a preset list of properties.
 
 The `GL Style Spec` requires each layer to have a source. **DO NOT PROVIDE THIS** for styling draw.
+
+The `GL Style Spec` also requires an id. Draw will provide this for you. If you wish to set this id to interact with draw layers, know that Draw will add `hot` and `cold` if no source is provided.
 
 Draw moves features between sources for performance gains, because of this it is recommeneded that you **DO NOT** provide a source for a style despite the fact the `GL Style Spec` requires a source. **Draw will provide the source for you automatically**.
 

--- a/src/options.js
+++ b/src/options.js
@@ -1,9 +1,11 @@
+var hat = require('hat');
+
 const defaultOptions = {
   defaultMode: 'simple_select',
   position: 'top-left',
   keybindings: true,
   displayControlsDefault: true,
-  styles: {},
+  styles: require('./lib/theme'),
   controls: {}
 };
 
@@ -29,5 +31,26 @@ module.exports = function(options = {controls: {}}) {
     options.controls = Object.assign(showControls, options.controls);
   }
 
-  return Object.assign(defaultOptions, options);
+  options = Object.assign(defaultOptions, options);
+
+  options.styles = options.styles.reduce((memo, style) => {
+    style.id = style.id || hat();
+    if (style.source) {
+      memo.push(style);
+    }
+    else {
+      var id = style.id;
+      style.id = `${id}.hot`;
+      style.source = 'mapbox-gl-draw-hot';
+      memo.push(JSON.parse(JSON.stringify(style)));
+
+      style.id = `${id}.cold`;
+      style.source = 'mapbox-gl-draw-cold';
+      memo.push(JSON.parse(JSON.stringify(style)));
+    }
+
+    return memo;
+  }, []);
+
+  return options;
 };

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,9 +1,6 @@
 var events = require('./events');
 var Store = require('./store');
 var ui = require('./ui');
-var hat = require('hat');
-
-var theme = require('./lib/theme');
 
 module.exports = function(ctx) {
 
@@ -64,38 +61,16 @@ module.exports = function(ctx) {
         type: 'geojson'
       });
 
-      for (let i = 0; i < theme.length; i++) {
-        if (theme[i].id === undefined) theme[i] = hat();
+      ctx.options.styles.forEach(style => {
+        ctx.map.addLayer(style);
+      });
 
-        let style = JSON.parse(JSON.stringify(theme[i]));
-        var id = style.id;
-
-        if (style.source) {
-          ctx.map.addLayer(style);
-        }
-        else {
-          style.id = `${id}.hot`;
-          style.source = 'mapbox-gl-draw-hot';
-          ctx.map.addLayer(style);
-
-          style.id = `${id}.cold`;
-          style.source = 'mapbox-gl-draw-cold';
-          ctx.map.addLayer(style);
-        }
-      }
       ctx.store.render();
     },
     removeLayers: function() {
-      for (let i = 0; i < theme.length; i++) {
-        let { id, source } = theme[i];
-        if (source) {
-          ctx.map.removeLayer(id);
-        }
-        else {
-          ctx.map.removeLayer(`${id}.hot`);
-          ctx.map.removeLayer(`${id}.cold`);
-        }
-      }
+      ctx.options.styles.forEach(style => {
+        ctx.map.removeLayer(style.id);
+      });
 
       ctx.map.removeSource('mapbox-gl-draw-cold');
       ctx.map.removeSource('mapbox-gl-draw-hot');

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -16,7 +16,7 @@ test('Options test', t => {
       position: 'top-left',
       keybindings: true,
       displayControlsDefault: true,
-      styles: {},
+      styles: Draw.options.styles,
       controls: {
         point: true,
         line_string: true,
@@ -35,7 +35,7 @@ test('Options test', t => {
       position: 'top-left',
       keybindings: true,
       displayControlsDefault: false,
-      styles: {},
+      styles: Draw.options.styles,
       controls: {
         point: false,
         line_string: false,
@@ -54,7 +54,7 @@ test('Options test', t => {
       position: 'top-left',
       keybindings: true,
       displayControlsDefault: false,
-      styles: {},
+      styles: Draw.options.styles,
       controls: {
         point: true,
         line_string: false,
@@ -62,6 +62,7 @@ test('Options test', t => {
         trash: false
       }
     };
+
     t.deepEquals(defaultOptions, Draw.options);
     t.end();
   });
@@ -73,7 +74,7 @@ test('Options test', t => {
       position: 'top-left',
       keybindings: true,
       displayControlsDefault: true,
-      styles: {},
+      styles: Draw.options.styles,
       controls: {
         point: false,
         line_string: true,
@@ -81,7 +82,43 @@ test('Options test', t => {
         trash: true
       }
     };
+
     t.deepEquals(defaultOptions, Draw.options);
+    t.end();
+  });
+
+  t.test('custom styles', t => {
+    var Draw = GLDraw({styles: [{
+      'id': 'custom-polygon',
+      'type': 'fill',
+      'filter': ['all', ['==', '$type', 'Polygon']],
+      'paint': {
+        'fill-color': '#f16852'
+      }
+    }]});
+
+    var styles = [
+      {
+        'id': 'custom-polygon.hot',
+        'source': 'mapbox-gl-draw-hot',
+        'type': 'fill',
+        'filter': ['all', ['==', '$type', 'Polygon']],
+        'paint': {
+          'fill-color': '#f16852'
+        }
+      },
+      {
+        'id': 'custom-polygon.cold',
+        'source': 'mapbox-gl-draw-cold',
+        'type': 'fill',
+        'filter': ['all', ['==', '$type', 'Polygon']],
+        'paint': {
+          'fill-color': '#f16852'
+        }
+      }
+    ];
+
+    t.deepEquals(styles, Draw.options.styles);
     t.end();
   });
 


### PR DESCRIPTION
@kiRach we were using this in the 0.4 version of Draw, but when we made the major change @mayagao also restyled Draw and so we stopped using our own internal custom style. So I was wrong to think this was working for us... :( sorry.

This reenables custom styling and provides a test to help us not regress again. Can you confirm?

Closes #288