### PR TITLE
Synthetic clicks

### DIFF
--- a/bench/lib/mouse_draw.js
+++ b/bench/lib/mouse_draw.js
@@ -7,20 +7,23 @@ module.exports = function(start, map) {
 
   var events = mouseEvents(map);
 
+  events.push('mousedown', {
+    x: start.x,
+    y: start.y
+  });
+
   events.push('mousemove', {
     x: start.x,
     y: start.y
   });
 
-  events.push('click', {
-    x: start.x,
-    y: start.y
-  }, true);
-
   for (var i=0; i<path.length; i++) {
+    events.push('mouseup', path[i]);
     events.push('mousemove', path[i]);
-    events.push('click', path[i]);
+    events.push('mousedown', path[i]);
   }
+
+  events.push('mouseup', path[path.length-1]);
 
   return function(cb) {
     events.run(cb);

--- a/bench/lib/mouse_trace.js
+++ b/bench/lib/mouse_trace.js
@@ -4,6 +4,8 @@ module.exports = function(ring, map) {
 
   var events = mouseEvents(map);
 
+  var lastPoint = null;
+
   for (var c=0; c<ring.length; c++) {
     var coord = ring[c];
     var point = map.project({
@@ -11,9 +13,15 @@ module.exports = function(ring, map) {
       lat: coord[1]
     });
     if (!isNaN(point.x)) {
+      lastPoint = point;
+      events.push('mouseup', point);
       events.push('mousemove', point);
-      events.push('click', point);
+      events.push('mousedown', point);
     }
+  }
+
+  if (lastPoint) {
+    events.push('mouseup', lastPoint);
   }
 
   return function(cb) {

--- a/src/lib/euclidean_distance.js
+++ b/src/lib/euclidean_distance.js
@@ -1,0 +1,4 @@
+module.exports = function(a, b) {
+    var x = a.x - b.x, y = a.y - b.y;
+    return Math.sqrt((x * x) + (y * y));
+};

--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -57,9 +57,6 @@ var ModeHandler = function(mode, DrawContext) {
     click: function(event) {
       delegate('click', event);
     },
-    doubleclick: function(event) {
-      delegate('doubleclick', event);
-    },
     mousemove: function(event) {
       delegate('mousemove', event);
     },

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -42,9 +42,7 @@ module.exports = function(ctx, opts) {
     start: function() {
       this.on('mousedown', isOfMetaType('vertex'), onVertex);
       this.on('mousedown', isOfMetaType('midpoint'), onMidpoint);
-      this.on('drag', () => {
-        return dragging;
-      }, function(e) {
+      this.on('drag', () => dragging, function(e) {
         e.originalEvent.stopPropagation();
         if (coordPos === null) {
           setupCoordPos();
@@ -66,8 +64,7 @@ module.exports = function(ctx, opts) {
         numCoords = null;
         startPos = null;
       });
-      this.on('click', noFeature, function(e) {
-        e.originalEvent.stopPropagation();
+      this.on('click', noFeature, function() {
         ctx.events.changeMode('simple_select');
       });
       this.on('trash', () => selectedCoordPaths.length > 0, function() {

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -65,7 +65,7 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
         var isSelected = selectedFeaturesById[id] !== undefined;
 
         if (isSelected && !isShiftDown(e)) {
-          this.on('mouseup', readyForDirectSelect, directSelect);
+          this.on('click', readyForDirectSelect, directSelect);
         }
         else if (isSelected && isShiftDown(e)) {
           delete selectedFeaturesById[id];
@@ -94,7 +94,7 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
       });
 
       this.on('drag', () => dragging, function(e) {
-        this.off('mouseup', readyForDirectSelect, directSelect);
+        this.off('click', readyForDirectSelect, directSelect);
         e.originalEvent.stopPropagation();
         if (featureCoords === null) {
           buildFeatureCoords();

--- a/test/line.test.js
+++ b/test/line.test.js
@@ -1,7 +1,7 @@
 import test from 'tape';
 import mapboxgl from 'mapbox-gl-js-mock';
 import GLDraw from '../';
-import { accessToken, createMap, features } from './utils';
+import { accessToken, createMap, features, click } from './utils';
 
 var feature = features.line;
 
@@ -20,7 +20,7 @@ test('Line draw class', function lineDrawClass(t){
   for (var i = 0; i < coords.length; i++) {
     let c = coords[i];
 
-    map.fire('click', {
+    click(map, {
       lngLat: {
         lng: c[0],
         lat: c[1]

--- a/test/point.test.js
+++ b/test/point.test.js
@@ -1,7 +1,7 @@
 import test from 'tape';
 import mapboxgl from 'mapbox-gl-js-mock';
 import GLDraw from '../';
-import { createMap } from './utils';
+import { createMap, click } from './utils';
 
 test('Point geometry class', t => {
   var map = createMap();
@@ -10,7 +10,7 @@ test('Point geometry class', t => {
 
   map.on('load', function() {
     Draw.changeMode('draw_point');
-    map.fire('click', {
+    click(map, {
       lngLat: {
         lng: 10,
         lat: 10

--- a/test/polygon.test.js
+++ b/test/polygon.test.js
@@ -1,7 +1,7 @@
 import test from 'tape';
 import mapboxgl from 'mapbox-gl-js-mock';
 import GLDraw from '../';
-import {createMap, features } from './utils';
+import {createMap, features, click } from './utils';
 
 var feature = features.polygon;
 
@@ -15,7 +15,7 @@ test('Polygon geometry class', t => {
     let coords = feature.geometry.coordinates[0];
     for (var i = 0; i < coords.length-1; i++) {
       var c = coords[i];
-      map.fire('click',{
+      click(map, {
         lngLat: {
           lng: c[0],
           lat: c[1]
@@ -27,7 +27,7 @@ test('Polygon geometry class', t => {
       });
     }
 
-    map.fire('click', {
+    click(map, {
       lngLat: {
         lng: coords[coords.length - 2][0],
         lat: coords[coords.length - 2][1]

--- a/test/utils.js
+++ b/test/utils.js
@@ -10,6 +10,11 @@ export function createMap() {
   return map;
 }
 
+export function click(map, payload) {
+  map.fire('mousedown', payload);
+  map.fire('mouseup', payload);
+}
+
 export const features = {
 
   line: {


### PR DESCRIPTION
Treats clicks as mousedown + mouseup events that do happen without the mouse moving too far or too much time happening between them.

Fixes
![](https://cloud.githubusercontent.com/assets/108094/14988482/00ade7e0-1122-11e6-93ca-fe93c0d1a269.gif)


The logic is borrowed from [iD](https://github.com/openstreetmap/iD/blob/d130c517b0a98c470aef269176bda729532f8ff1/js/id/behavior/draw.js#L34-L56).

@samanpwbb for the review.