### PR TITLE
Throw error when using direct_select with points

### DIFF
--- a/API.md
+++ b/API.md
@@ -185,7 +185,9 @@ For `simple_select` options is an array of ids. It is optional. If provided, the
 
 Lets you select, delete and drag vertices.
 
-For `direct_select`options is a single featureId. It is required. This feature will be active for the duration of the mode.
+For `direct_select` options is a single featureId. It is required. This feature will be active for the duration of the mode.
+
+`direct_select` mode doesn't handle point features.
 
 #### Drawing modes:
 

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -5,6 +5,11 @@ module.exports = function(ctx, opts) {
   var featureId = opts.featureId;
   var feature = ctx.store.get(featureId);
 
+  if (feature.type === 'Point') {
+    throw new TypeError('Mapbox GL Draw direct_select mode doesn\'t handle ' +
+    'point features (https://github.com/mapbox/mapbox-gl-draw/issues/310)');
+  }
+
   var dragging = opts.isDragging || false;
   var startPos = opts.startPos || null;
   var coordPos = null;

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -38,6 +38,12 @@ var timeout = function(t, time, msg) {
 var Draw = GLDraw();
 map.addControl(Draw);
 
+test('draw.direct_select event', t => {
+  let id = Draw.add(feature);
+  t.throws(() => Draw.changeMode('direct_select', {featureId: id}));
+  t.end();
+});
+
 test('draw.deleted event', t => {
   t = timeout(t, 100, 'failed to fire draw.deleted');
   map.once('draw.deleted', e => {


### PR DESCRIPTION
Throw error when using `direct_select` with points as mentioned in mapbox/mapbox-gl-draw#310