### PR TITLE
Speed improvements

### DIFF
--- a/API.md
+++ b/API.md
@@ -252,7 +252,7 @@ If you need to style gl-draw for debugging sources the source names are `mapbox-
 
 property | values | function
 --- | --- | ---
-meta | feature, midpoint, vertex, too-small | `midpoint` and `vertex` are used on points added to the map to communicate polygon and line handles. `feature` is used for all features added by the user. `too-small` is used to indicate a point that represents the center of a collection of features that are too small at the current zoom level to be seen.
+meta | feature, midpoint, vertex | `midpoint` and `vertex` are used on points added to the map to communicate polygon and line handles. `feature` is used for all features added by the user.
 active | true, false | A feature is active when it is 'selected' in the current mode. `true` and `false` are strings.
 mode |  simple_select, direct_select, draw_point, draw_line_string, draw_polygon | Indicates which mode Draw is currently in.
 hover | true, false | `true` and `false` are strings. `hover` is true when the mouse is over the feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.4
+
+* Major speed improvement while drawing
+* Removes displaying polygons and lines as points when they are very small
+
 ## 0.6.0
 
 * Draw.add now runs geojsonhint on provided features to confirm they are valid geojson

--- a/debug/index.html
+++ b/debug/index.html
@@ -109,22 +109,33 @@ location.hash.replace(/^#/,'').split('/').reduce(function(args, val, i, hash){
       Draw.changeMode('draw_polygon');
     };
 
-    var req = new XMLHttpRequest();
-    req.onerror = function() {
-      throw new FriendlyError('Network Error');
-    };
-    req.onload = () => {
-      var fc = JSON.parse(req.response);
-      fc.features.forEach(feature => {
-        if(feature.geometry.type.startsWith('Multi') === false) {
-          Draw.add(feature);
-        }
-      });
+    var counter = 0;
 
-    };
-    var uri = 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_geography_regions_polys.geojson';
-    req.open('GET', uri);
-    req.send();
+    var loadData = function(uri) {
+      var req = new XMLHttpRequest();
+      req.onerror = function() {
+        throw new FriendlyError('Network Error');
+      };
+      req.onload = () => {
+        counter++;
+        console.log('counter', counter);
+        var fc = JSON.parse(req.response);
+        fc.features.forEach(feature => {
+          if(feature.geometry.type.startsWith('Multi') === false) {
+            Draw.add(feature);
+          }
+        });
+
+      };
+      req.open('GET', uri);
+      req.send();
+    }
+
+    loadData('https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_geography_regions_polys.geojson');
+
+    loadData('https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_rivers_north_america.geojson');
+
+    // loadData('https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_admin_1_label_points.geojson');
 
   });
 

--- a/debug/index.html
+++ b/debug/index.html
@@ -109,35 +109,32 @@ location.hash.replace(/^#/,'').split('/').reduce(function(args, val, i, hash){
       Draw.changeMode('draw_polygon');
     };
 
-    var counter = 0;
-
-    var loadData = function(uri) {
-      var req = new XMLHttpRequest();
-      req.onerror = function() {
-        throw new FriendlyError('Network Error');
-      };
-      req.onload = () => {
-        counter++;
-        console.log('counter', counter);
-        var fc = JSON.parse(req.response);
-        fc.features.forEach(feature => {
-          if(feature.geometry.type.startsWith('Multi') === false) {
-            Draw.add(feature);
-          }
-        });
-
-      };
-      req.open('GET', uri);
-      req.send();
-    }
-
-    loadData('https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_geography_regions_polys.geojson');
-
-    loadData('https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_rivers_north_america.geojson');
-
-    // loadData('https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_admin_1_label_points.geojson');
-
   });
+
+  var loadData = function(uri) {
+  var req = new XMLHttpRequest();
+  req.onerror = function() {
+    throw new FriendlyError('Network Error');
+  };
+  req.onload = () => {
+    var fc = JSON.parse(req.response);
+    fc.features.forEach(feature => {
+      if(feature.geometry.type.startsWith('Multi') === false) {
+        Draw.add(feature);
+      }
+    });
+
+  };
+  req.open('GET', uri);
+  req.send();
+}
+
+console.log('use `loadData(url)` to load in FeatureCollections to Draw via url');
+console.log('5.51MB Polygons - https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_geography_regions_polys.geojson');
+
+console.log('4.99MB LineStirings - https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_rivers_north_america.geojson');
+
+console.log('4.03MB Points - https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_admin_1_label_points.geojson');
 
   (function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;right:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='//rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})();
 </script>

--- a/debug/index.html
+++ b/debug/index.html
@@ -109,6 +109,23 @@ location.hash.replace(/^#/,'').split('/').reduce(function(args, val, i, hash){
       Draw.changeMode('draw_polygon');
     };
 
+    var req = new XMLHttpRequest();
+    req.onerror = function() {
+      throw new FriendlyError('Network Error');
+    };
+    req.onload = () => {
+      var fc = JSON.parse(req.response);
+      fc.features.forEach(feature => {
+        if(feature.geometry.type.startsWith('Multi') === false) {
+          Draw.add(feature);
+        }
+      });
+
+    };
+    var uri = 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_geography_regions_polys.geojson';
+    req.open('GET', uri);
+    req.send();
+
   });
 
   (function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;right:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='//rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})();

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "dependencies": {
     "geojsonhint": "^1.2.0",
     "hat": "0.0.3",
-    "immutable": "^3.8.1",
     "point-geometry": "0.0.0",
     "ramda": "^0.17.1",
     "turf-area": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-draw",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A drawing component for Mapbox GL JS",
   "homepage": "https://github.com/mapbox/mapbox-gl-draw",
   "author": "mapbox",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "geojsonhint": "^1.2.0",
     "hat": "0.0.3",
+    "immutable": "^3.8.1",
     "point-geometry": "0.0.0",
     "ramda": "^0.17.1",
     "turf-area": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "hat": "0.0.3",
     "point-geometry": "0.0.0",
     "ramda": "^0.17.1",
-    "turf-area": "^1.1.1",
-    "turf-centroid": "^1.1.3",
-    "turf-envelope": "^1.0.2"
+    "turf-area": "^1.1.1"
   }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -46,17 +46,13 @@ module.exports = function(ctx) {
       geojson = JSON.parse(JSON.stringify(geojson));
 
       geojson.id = geojson.id || hat();
-      if (ctx.store.needsUpdate(geojson)) {
-        var model = featureTypes[geojson.geometry.type];
 
-        let internalFeature = new model(ctx, geojson);
-        ctx.store.add(internalFeature);
-        ctx.store.render();
-      }
-      else {
-        let internalFeature = ctx.store.get(geojson.id);
-        internalFeature.properties = geojson.properties;
-      }
+      var model = featureTypes[geojson.geometry.type];
+
+      let internalFeature = new model(ctx, geojson);
+      ctx.store.add(internalFeature);
+      ctx.store.render();
+
       return geojson.id;
     },
     get: function (id) {

--- a/src/events.js
+++ b/src/events.js
@@ -104,10 +104,6 @@ module.exports = function(ctx) {
     }
   };
 
-  events.deleted = function() {
-    ctx.store.setDirty();
-  };
-
   events.zoomend = function() {
     ctx.store.changeZoom();
   };
@@ -150,10 +146,6 @@ module.exports = function(ctx) {
 
       ctx.container.addEventListener('keydown', events.keydown);
       ctx.container.addEventListener('keyup', events.keyup);
-
-      ctx.map.on('draw.deleted', events.deleted);
-
-      ctx.map.on('zoomend', events.zoomend);
     },
     removeEventListeners: function() {
       ctx.map.off('mousemove', events.mousemove);
@@ -163,10 +155,6 @@ module.exports = function(ctx) {
 
       ctx.container.removeEventListener('keydown', events.keydown);
       ctx.container.removeEventListener('keyup', events.keyup);
-
-      ctx.map.off('draw.deleted', events.deleted);
-
-      ctx.map.off('zoomend', events.zoomend);
     }
   };
 

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -4,10 +4,19 @@ var Feature = function(ctx, geojson) {
   this.ctx = ctx;
   this.properties = geojson.properties || {};
   this.coordinates = geojson.geometry.coordinates;
+  this.atLastRender = null;
   this.id = geojson.id || hat();
   this.type = geojson.geometry.type;
   ctx.store.add(this);
 };
+
+Feature.prototype.needsUpdate = function() {
+  return this.coordinates.join(' ') !== this.atLastRender;
+}
+
+Feature.prototype.pegCoords = function() {
+   this.atLastRender = this.coordinates.join(' ');
+}
 
 Feature.prototype.getCoordinates = function() {
   return JSON.parse(JSON.stringify(this.coordinates));

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -12,12 +12,12 @@ var Feature = function(ctx, geojson) {
 
 Feature.prototype.changed = function() {
   this.ctx.store.featureChanged(this.id);
-}
+};
 
 Feature.prototype.setCoordinates = function(coords) {
   this.coordinates = coords;
   this.changed();
-}
+};
 
 Feature.prototype.getCoordinates = function() {
   return JSON.parse(JSON.stringify(this.coordinates));

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -10,12 +10,13 @@ var Feature = function(ctx, geojson) {
   ctx.store.add(this);
 };
 
-Feature.prototype.needsUpdate = function() {
-  return this.coordinates.join(' ') !== this.atLastRender;
+Feature.prototype.changed = function() {
+  this.ctx.store.featureChanged(this.id);
 }
 
-Feature.prototype.pegCoords = function() {
-   this.atLastRender = this.coordinates.join(' ');
+Feature.prototype.setCoordinates = function(coords) {
+  this.coordinates = coords;
+  this.changed();
 }
 
 Feature.prototype.getCoordinates = function() {

--- a/src/feature_types/line_string.js
+++ b/src/feature_types/line_string.js
@@ -11,6 +11,7 @@ LineString.prototype.isValid = function() {
 };
 
 LineString.prototype.addCoordinate = function(path, lng, lat) {
+  this.changed();
   this.selectedCoords = {};
   var id = parseInt(path, 10);
   this.coordinates.splice(id, 0, [lng, lat]);
@@ -22,10 +23,12 @@ LineString.prototype.getCoordinate = function(path) {
 };
 
 LineString.prototype.removeCoordinate = function(path) {
+  this.changed();
   this.coordinates.splice(parseInt(path, 10), 1);
 };
 
 LineString.prototype.updateCoordinate = function(path, lng, lat) {
+  this.changed();
   var id = parseInt(path, 10);
   this.coordinates[id] = [lng, lat];
 };

--- a/src/feature_types/point.js
+++ b/src/feature_types/point.js
@@ -11,6 +11,7 @@ Point.prototype.isValid = function() {
 };
 
 Point.prototype.updateCoordinate = function(path, lng, lat) {
+  this.changed();
   this.coordinates = [lng, lat];
 };
 

--- a/src/feature_types/polygon.js
+++ b/src/feature_types/polygon.js
@@ -14,6 +14,7 @@ Polygon.prototype.isValid = function() {
 };
 
 Polygon.prototype.addCoordinate = function(path, lng, lat) {
+  this.changed();
   var ids = path.split('.').map(x => parseInt(x, 10));
 
   var ring = this.coordinates[ids[0]];
@@ -22,6 +23,7 @@ Polygon.prototype.addCoordinate = function(path, lng, lat) {
 };
 
 Polygon.prototype.removeCoordinate = function(path) {
+  this.changed();
   var ids = path.split('.').map(x => parseInt(x, 10));
   var ring = this.coordinates[ids[0]];
   if (ring) {
@@ -43,6 +45,7 @@ Polygon.prototype.getCoordinates = function() {
 };
 
 Polygon.prototype.updateCoordinate = function(path, lng, lat) {
+  this.changed();
   var parts = path.split('.');
   var ringId = parseInt(parts[0], 10);
   var coordId = parseInt(parts[1], 10);

--- a/src/lib/features_at.js
+++ b/src/lib/features_at.js
@@ -1,6 +1,6 @@
 var area = require('turf-area');
 
-var metas = ['feature', 'midpoint', 'vertex', 'too-small'];
+var metas = ['feature', 'midpoint', 'vertex'];
 
 var geometryTypeValues = {
   'Polygon': 2,

--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -32,8 +32,7 @@ var ModeHandler = function(mode, DrawContext) {
       DrawContext.map.fire(`draw.${modename}.${event}`, payload);
     },
     render: function(id) {
-      console.log('will update', id);
-      DrawContext.store.featureChanged(id)
+      DrawContext.store.featureChanged(id);
     }
   };
 

--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -30,6 +30,10 @@ var ModeHandler = function(mode, DrawContext) {
     fire: function(event, payload) {
       var modename = DrawContext.events.currentModeName();
       DrawContext.map.fire(`draw.${modename}.${event}`, payload);
+    },
+    render: function(id) {
+      console.log('will update', id);
+      DrawContext.store.featureChanged(id)
     }
   };
 

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -175,15 +175,5 @@ module.exports = [
       'circle-color': '#03A9F4'
     },
     'interactive': true
-  },
-  {
-    'id': 'gl-draw-too-small',
-    'type': 'circle',
-    'filter': ['all', ['==', '$type', 'Point'], ['==', 'meta', 'too-small']],
-    'paint': {
-      'circle-radius': 5,
-      'circle-color': '#037994'
-    },
-    'interactive': true
   }
 ];

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -77,7 +77,7 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
         else {
           //make selected
           var wasSelected = Object.keys(selectedFeaturesById);
-          wasSelected.forEach(id => this.render(id));
+          wasSelected.forEach(wereId => this.render(wereId));
           selectedFeaturesById = {};
           selectedFeaturesById[id] = ctx.store.get(id);
           this.fire('selected.end', {featureIds:wasSelected});

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -40,6 +40,7 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
       this.on('click', noFeature, function() {
         var wasSelected = Object.keys(selectedFeaturesById);
         selectedFeaturesById = {};
+        wasSelected.forEach(id => this.render(id));
         this.fire('selected.end', {featureIds: wasSelected});
       });
 
@@ -50,11 +51,6 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
           isDragging: true,
           startPos: e.lngLat
         });
-      });
-
-      this.on('mousedown', isOfMetaType('too-small'), function(e) {
-        var bounds = JSON.parse(e.featureTarget.properties.bounds, {padding: 100});
-        ctx.map.fitBounds(bounds);
       });
 
       this.on('mousedown', isFeature, function(e) {
@@ -70,19 +66,23 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
         else if (isSelected && isShiftDown(e)) {
           delete selectedFeaturesById[id];
           this.fire('selected.end', {featureIds:[id]});
+          this.render(id);
         }
         else if (!isSelected && isShiftDown(e)) {
           // add to selected
           selectedFeaturesById[id] = ctx.store.get(id);
           this.fire('selected.start', {featureIds:[id]});
+          this.render(id);
         }
         else {
           //make selected
           var wasSelected = Object.keys(selectedFeaturesById);
+          wasSelected.forEach(id => this.render(id));
           selectedFeaturesById = {};
           selectedFeaturesById[id] = ctx.store.get(id);
           this.fire('selected.end', {featureIds:wasSelected});
           this.fire('selected.start', {featureIds:[id]});
+          this.render(id);
         }
       });
 
@@ -109,14 +109,16 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
         for (var i = 0; i < numFeatures; i++) {
           var feature = features[i];
           if (feature.type === 'Point') {
-            feature.coordinates[0] = featureCoords[i][0] + lngD;
-            feature.coordinates[1] = featureCoords[i][1] + latD;
+            feature.setCoordinates([
+              featureCoords[i][0] + lngD,
+              featureCoords[i][1] + latD
+            ]);
           }
           else if (feature.type === 'LineString') {
-            feature.coordinates = featureCoords[i].map(coordMap);
+            feature.setCoordinates(featureCoords[i].map(coordMap));
           }
           else if (feature.type === 'Polygon') {
-            feature.coordinates = featureCoords[i].map(ringMap);
+            feature.setCoordinates(featureCoords[i].map(ringMap));
           }
         }
       });

--- a/src/render.js
+++ b/src/render.js
@@ -1,6 +1,3 @@
-var turfEnvelope = require('turf-envelope');
-var turfCentroid = require('turf-centroid');
-
 module.exports = function render() {
   var isStillAlive = this.ctx.map && this.ctx.map.getSource('mapbox-gl-draw-hot') !== undefined;
   if (isStillAlive) { // checks to make sure we still have a map
@@ -29,8 +26,6 @@ module.exports = function render() {
       return newHotIds.indexOf(id) === -1;
     });
 
-    console.log('change', this.isDirty, newHotIds.length, newColdIds.length, this.changedIds.length);
-
     let changed = [];
     newHotIds.concat(newColdIds).map(function prepForViewUpdates(id) {
       if (newHotIds.indexOf(id) > -1) {
@@ -53,7 +48,7 @@ module.exports = function render() {
       }.bind(this));
     }.bind(this));
 
-    if (lastColdCount != this.sources.cold.length) {
+    if (lastColdCount !== this.sources.cold.length) {
       this.ctx.map.getSource('mapbox-gl-draw-cold').setData({
         type: 'FeatureCollection',
         features: this.sources.cold

--- a/src/render.js
+++ b/src/render.js
@@ -1,6 +1,5 @@
 var turfEnvelope = require('turf-envelope');
 var turfCentroid = require('turf-centroid');
-var Immutable = require('immutable');
 
 module.exports = function render() {
   var isStillAlive = this.ctx.map && this.ctx.map.getSource('mapbox-gl-draw-hot') !== undefined;
@@ -10,103 +9,51 @@ module.exports = function render() {
       mode: mode
     });
 
-    var zoomUpdate = Math.abs(this.zoomRender - this.zoomLevel) > 1 || this.isDirty;
-
     var newHotIds = [];
     var newColdIds = [];
 
-    if (zoomUpdate) {
-      this.featureIds.forEach(id => {
-        if (this.features[id].needsUpdate()) {
-          newHotIds.push(id);
-        }
-        else {
-          newColdIds.push(id);
-        }
-      })
+    if (this.isDirty) {
+      newColdIds = this.featureIds;
     }
     else {
-      newHotIds = this.featureIds.filter(id => this.features[id].needsUpdate());
-      newColdIds = this.sources.hot.filter(geojson => {
-        return geojson.properties.id && newHotIds.indexOf(geojson.properties.id) === -1
-      }).map(geojson => geojson.properties.id);
+      newHotIds = this.changedIds.filter(id => this.features[id] !== undefined);
+      newColdIds = this.sources.hot.filter(function getColdIds(geojson) {
+        return geojson.properties.id && newHotIds.indexOf(geojson.properties.id) === -1 && this.features[geojson.properties.id] !== undefined;
+      }.bind(this)).map(geojson => geojson.properties.id);
     }
 
     this.sources.hot = [];
-    this.sources.cold = zoomUpdate ? [] : this.sources.cold.filter(geojson => {
+    let lastColdCount = this.sources.cold.length;
+    this.sources.cold = this.isDirty ? [] : this.sources.cold.filter(function saveColdFeatures(geojson) {
       var id = geojson.properties.id || geojson.properties.parent;
       return newHotIds.indexOf(id) === -1;
     });
 
-    let changed = [];
+    console.log('change', this.isDirty, newHotIds.length, newColdIds.length, this.changedIds.length);
 
-    newHotIds.concat(newColdIds).map(id => {
+    let changed = [];
+    newHotIds.concat(newColdIds).map(function prepForViewUpdates(id) {
       if (newHotIds.indexOf(id) > -1) {
         return {source: 'hot', 'id': id};
       }
       else {
         return {source: 'cold', 'id': id};
       }
-    }).forEach(change => {
+    }).forEach(function calculateViewUpdate(change) {
       let {id, source} = change;
       let feature = this.features[id];
       let featureInternal = feature.internal(mode);
 
       if (source === 'hot' && feature.isValid()) {
         changed.push(feature.toGeoJSON());
-        feature.pegCoords();
       }
 
-      if (featureInternal.geometry.type !== 'Point') {
-        var envelope = turfEnvelope({
-          type: 'FeatureCollection',
-          features: [featureInternal]
-        });
-
-        var topLeftCoord = envelope.geometry.coordinates[0][0];
-        var bottomRightCoord = envelope.geometry.coordinates[0][2];
-
-        var topLeftPixels = this.ctx.map.project({
-          lng: topLeftCoord[0],
-          lat: topLeftCoord[1]
-        });
-
-        var bottomRightPixels = this.ctx.map.project({
-          lng: bottomRightCoord[0],
-          lat: bottomRightCoord[1]
-        });
-
-        var dx = Math.abs(topLeftPixels.x - bottomRightPixels.x);
-        var dy = Math.abs(topLeftPixels.y - bottomRightPixels.y);
-
-        var distance = Math.pow((dx * dx) + (dy * dy), .5);
-
-        if (distance < 10) {
-          featureInternal.properties.meta = 'too-small';
-          featureInternal.properties.bounds = JSON.stringify([topLeftCoord, bottomRightCoord]);
-          featureInternal.properties.point = turfCentroid({
-            type: 'FeatureCollection',
-            features: [featureInternal]
-          });
-        }
-      }
-
-      this.ctx.events.currentModeRender(featureInternal, (geojson => {
-        var about = geojson.properties;
-
-        if (about.meta === 'too-small' && about.point) {
-          geojson.geometry = about.point.geometry;
-        }
-
-        delete about.point;
-
-        geojson.properties = about;
-
+      this.ctx.events.currentModeRender(featureInternal, function addGeoJsonToView(geojson) {
         this.sources[source].push(geojson);
-      }));
-    });
+      }.bind(this));
+    }.bind(this));
 
-    if (newColdIds.length > 0) {
+    if (lastColdCount != this.sources.cold.length) {
       this.ctx.map.getSource('mapbox-gl-draw-cold').setData({
         type: 'FeatureCollection',
         features: this.sources.cold
@@ -124,5 +71,5 @@ module.exports = function render() {
 
   }
   this.isDirty = false;
-  this.zoomRender = this.zoomLevel;
+  this.changedIds = [];
 };

--- a/src/render.js
+++ b/src/render.js
@@ -74,7 +74,7 @@ module.exports = function render() {
       let needsUpdate = feature.isValid() && this.ctx.store.needsUpdate(id, coordString);
 
       if (needsUpdate) {
-        this.featureHistory[id] = coordString;
+        this.featureHistory = this.featureHistory.set(id, coordString)
         changed.push(feature.toGeoJSON());
         this.featureHistoryJSON[id] = featureInternal;
       }

--- a/src/store.js
+++ b/src/store.js
@@ -6,9 +6,10 @@ var Store = module.exports = function(ctx) {
   this.ctx = ctx;
   this.features = {};
   this.featureIds = [];
-  this.renderHistory = {};
-  this.featureHistory = Immutable.Map();
-  this.featureHistoryJSON = {};
+  this.sources = {
+    hot: [],
+    cold: []
+  };
   this.render = throttle(render, 16, this);
   this.isDirty = false;
   this.zoomLevel = ctx.map.getZoom();
@@ -56,6 +57,7 @@ Store.prototype.delete = function (ids) {
       deleted.push(feature.toGeoJSON());
       delete this.features[id];
       this.featureHistory = this.featureHistory.delete(id);
+      this.featureHistoryJSON = this.featureHistoryJSON.delete(id);
       this.featureIds.splice(idx, 1);
     }
   });

--- a/src/store.js
+++ b/src/store.js
@@ -7,16 +7,16 @@ var Store = module.exports = function(ctx) {
   this.featureIds = [];
   this.renderHistory = {};
   this.featureHistory = {};
+  this.featureHistoryJSON = {};
   this.render = throttle(render, 16, this);
   this.isDirty = false;
   this.zoomLevel = ctx.map.getZoom();
   this.zoomRender = this.zoomLevel;
 };
 
-Store.prototype.needsUpdate = function(geojson) {
-  var feature = this.features[geojson.id];
-  var coords = JSON.stringify(geojson.geometry.coordinates);
-  return !(feature && this.featureHistory[geojson.id] === coords);
+Store.prototype.needsUpdate = function(id, coordString) {
+  var feature = this.features[id];
+  return !(feature && this.featureHistory[id] === coordString);
 };
 
 Store.prototype.setDirty = function() {

--- a/src/store.js
+++ b/src/store.js
@@ -1,12 +1,13 @@
 var {throttle} = require('./lib/util');
 var render = require('./render');
+var Immutable = require('immutable');
 
 var Store = module.exports = function(ctx) {
   this.ctx = ctx;
   this.features = {};
   this.featureIds = [];
   this.renderHistory = {};
-  this.featureHistory = {};
+  this.featureHistory = Immutable.Map();
   this.featureHistoryJSON = {};
   this.render = throttle(render, 16, this);
   this.isDirty = false;
@@ -16,7 +17,7 @@ var Store = module.exports = function(ctx) {
 
 Store.prototype.needsUpdate = function(id, coordString) {
   var feature = this.features[id];
-  return !(feature && this.featureHistory[id] === coordString);
+  return !(feature && this.featureHistory.get(id) === coordString);
 };
 
 Store.prototype.setDirty = function() {
@@ -54,7 +55,7 @@ Store.prototype.delete = function (ids) {
       var feature = this.get(id);
       deleted.push(feature.toGeoJSON());
       delete this.features[id];
-      delete this.featureHistory[id];
+      this.featureHistory = this.featureHistory.delete(id);
       this.featureIds.splice(idx, 1);
     }
   });

--- a/src/store.js
+++ b/src/store.js
@@ -15,13 +15,15 @@ var Store = module.exports = function(ctx) {
   this.changedIds = [];
 };
 
-Store.prototype.setDirty = function() { this.isDirty = true; }
+Store.prototype.setDirty = function() {
+  this.isDirty = true;
+};
 
 Store.prototype.featureChanged = function(id) {
   if (this.changedIds.indexOf(id) === -1) {
     this.changedIds.push(id);
   }
-}
+};
 
 Store.prototype.add = function(feature) {
   this.featureChanged(feature.id);


### PR DESCRIPTION
Updated render to only loop over the features that have changed and dropped zoom based rendering so that Draw doesn't need to loop over every feature on zoom.

When a feature is hot and updated the rendering performance is constant. When it goes cold Draw's rendering is constant but gl-js is not. We might want to look into having multiple cold sources based on the number of features in Draw...

With the earcut version of gl-js this is running at about 55fps on my computer with 20mb worth of data loaded. On the non-earcut version it runs around 33fps.