### PR TITLE
Add draw.mode.simple_select.selected events

### DIFF
--- a/API.md
+++ b/API.md
@@ -232,11 +232,11 @@ This is fired when feature coordinates are changed. It is fired just after the c
 
 ### draw.mode.simple_select.selected.start
 
-This is fired every time a feature is selected in the default mode. The payload is an array of feature ids being selected. This is **NOT** fired when the mode starts as this information is in the `draw.modechange` event.
+This is fired every time a feature is selected in the default mode. The payload is an object containing the `featureIds` being selected. This is **NOT** fired when the mode starts as this information is in the `draw.modechange` event.
 
 ### draw.mode.simple_select.selected.end
 
-This is fired every time a feature is unselected in the default mode. The payload is an array of feature ids being unselected. This is **NOT** fired when the mode stops, as this can be assumed via the `draw.modechange` event.
+This is fired every time a feature is unselected in the default mode. The payload is an object containing the `featureIds` being unselected. This is **NOT** fired when the mode stops, as this can be assumed via the `draw.modechange` event.
 
 ## Styling Draw
 

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -43,6 +43,7 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
         var wasSelected = Object.keys(selectedFeaturesById);
         selectedFeaturesById = {};
         this.fire('selected.end', {featureIds: wasSelected});
+        ctx.map.fire('draw.mode.simple_select.selected.end', {featureIds: wasSelected});
         wasSelected.forEach(id => this.render(id));
       });
 
@@ -68,12 +69,14 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
         else if (isSelected && isShiftDown(e)) {
           delete selectedFeaturesById[id];
           this.fire('selected.end', {featureIds:[id]});
+          ctx.map.fire('draw.mode.simple_select.selected.end', {featureIds:[id]});
           this.render(id);
         }
         else if (!isSelected && isShiftDown(e)) {
           // add to selected
           selectedFeaturesById[id] = ctx.store.get(id);
           this.fire('selected.start', {featureIds:[id]});
+          ctx.map.fire('draw.mode.simple_select.selected.start', {featureIds:[id]});
           this.render(id);
         }
         else {
@@ -83,7 +86,9 @@ module.exports = function(ctx, startingSelectedFeatureIds) {
           selectedFeaturesById = {};
           selectedFeaturesById[id] = ctx.store.get(id);
           this.fire('selected.end', {featureIds:wasSelected});
+          ctx.map.fire('draw.mode.simple_select.selected.end', {featureIds:wasSelected});
           this.fire('selected.start', {featureIds:[id]});
+          ctx.map.fire('draw.mode.simple_select.selected.start', {featureIds:[id]});
           this.render(id);
         }
       });


### PR DESCRIPTION
It appears that the `draw.mode.simple_select.selected.start` and `draw.mode.simple_select.selected.end` events [mentioned in the docs](https://github.com/mapbox/mapbox-gl-draw/blob/master/API.md#drawmodesimple_selectselectedstart) have not yet been implemented, as the existing `selected.start` and `selected.end` events are just used internally and not fired on `ctx.map`. This PR adds support for both events.