### PR TITLE
New events

### DIFF
--- a/API.md
+++ b/API.md
@@ -73,7 +73,7 @@ console.log(Draw.get(id));
 ```
 
 ---
-### `.getFeatureIdsAt(Number: x, Number: y) -> [featureId, featuresId]
+### `.getFeatureIdsAt(Number: x, Number: y) -> [featureId, featuresId]`
 
 This method takes an x and y from pixel space and returns a list of
 features currently rendered by draws at that spot.
@@ -85,6 +85,10 @@ var featureIds = Draw.getFeatureIdsAt(20, 20);
 console.log(featureIds)
 //=> ['top-feature-at-20-20', 'another-feature-at-20-20']
 ```
+---
+### `.getSelectedIds() -> [featureId, featuresId]`
+
+This method returns the feature ids for all features currently in a selected state. If no features are currently selected than it will return an empty array.
 
 ---
 ###`.getAll() -> Object`

--- a/API.md
+++ b/API.md
@@ -242,13 +242,35 @@ This is fired when feature coordinates are changed, and there is a mouse click a
 }
 ```
 
-### draw.mode.simple_select.selected.start
+### draw.select
 
-This is fired every time a feature is selected in the default mode. The payload is an array of feature ids being selected. This is **NOT** fired when the mode starts as this information is in the `draw.modechange` event.
+Fired when a feature is selected. The payload is the GeoJSON of the feature that was selected.
 
-### draw.mode.simple_select.selected.end
+The `select` event will fire in the following contexts:
 
-This is fired every time a feature is unselected in the default mode. The payload is an array of feature ids being unselected. This is **NOT** fired when the mode stops, as this can be assumed via the `draw.modechange` event.
+- When a new feature is created (because it is selected on creation).
+- When a feature is added to an existing selection with `shift+click`.
+- When a feature is included within a box selection.
+
+```js
+{
+  "features": [{ ... }]
+}
+```
+
+### draw.deselect
+
+Fired when a feature is deselected. The payload is the GeoJSON of the feature that was deselected.
+
+The `deselect` event will fire when there is a click outside a selected feature, whether that click is on no features or on another feature (without using `shift+click` to add something else to the existing selection).
+
+(The event does not fire when a feature is delete.)
+
+```js
+{
+  "features": [{ ... }]
+}
+```
 
 ## Styling Draw
 

--- a/src/api.js
+++ b/src/api.js
@@ -20,6 +20,9 @@ module.exports = function(ctx) {
       var features = featuresAt({point: {x, y}}, null, ctx);
       return features.map(feature => feature.properties.id);
     },
+    getSelectedIds: function () {
+      return ctx.store.getSelectedIds();
+    },
     add: function (geojson, validateGeoJSON=true) {
        if (geojson.type !== 'FeatureCollection' && !geojson.geometry) {
         geojson = {

--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -55,7 +55,6 @@ var ModeHandler = function(mode, DrawContext) {
     render: mode.render || function(geojson) {return geojson; },
     stop: function() {
       if (mode.stop) mode.stop();
-      DrawContext.store.clearSelected();
     },
     drag: function(event) {
       delegate('drag', event);

--- a/src/lib/to_dense_array.js
+++ b/src/lib/to_dense_array.js
@@ -1,0 +1,11 @@
+/**
+ * Derive a dense array (no `undefined`s) from a single value or array.
+ *
+ * @param {any} x
+ * @return {Array<any>}
+ */
+function toDenseArray(x) {
+  return [].concat(x).filter(y => y !== undefined);
+}
+
+module.exports = toDenseArray;

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -45,7 +45,6 @@ module.exports = function(ctx, opts) {
 
   return {
     start: function() {
-      ctx.store.setSelected(featureId);
       ctx.map.doubleClickZoom.disable();
       this.on('mousedown', isOfMetaType('vertex'), onVertex);
       this.on('mousedown', isOfMetaType('midpoint'), onMidpoint);

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -45,6 +45,7 @@ module.exports = function(ctx, opts) {
 
   return {
     start: function() {
+      ctx.store.setSelected(featureId);
       ctx.map.doubleClickZoom.disable();
       this.on('mousedown', isOfMetaType('vertex'), onVertex);
       this.on('mousedown', isOfMetaType('midpoint'), onMidpoint);

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -52,6 +52,7 @@ module.exports = function(ctx) {
 
   return {
     start: function() {
+      ctx.store.clearSelected();
       setTimeout(() => {
         if (ctx.map && ctx.map.doubleClickZoom) {
           ctx.map.doubleClickZoom.disable();

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -52,7 +52,6 @@ module.exports = function(ctx) {
 
   return {
     start: function() {
-      ctx.store.setSelected(feature.id);
       setTimeout(() => {
         if (ctx.map && ctx.map.doubleClickZoom) {
           ctx.map.doubleClickZoom.disable();

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -30,6 +30,7 @@ module.exports = function(ctx) {
 
   return {
     start: function() {
+      ctx.store.clearSelected();
       ctx.ui.setClass({mouse:'add'});
       ctx.ui.setButtonActive(types.POINT);
       this.on('click', () => true, onClick);

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -30,7 +30,6 @@ module.exports = function(ctx) {
 
   return {
     start: function() {
-      ctx.store.setSelected(feature.id);
       ctx.ui.setClass({mouse:'add'});
       ctx.ui.setButtonActive(types.POINT);
       this.on('click', () => true, onClick);

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -53,7 +53,6 @@ module.exports = function(ctx) {
 
   return {
     start: function() {
-      ctx.store.setSelected(feature.id);
       setTimeout(() => {
         if (ctx.map && ctx.map.doubleClickZoom) {
           ctx.map.doubleClickZoom.disable();

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -53,6 +53,7 @@ module.exports = function(ctx) {
 
   return {
     start: function() {
+      ctx.store.clearSelected();
       setTimeout(() => {
         if (ctx.map && ctx.map.doubleClickZoom) {
           ctx.map.doubleClickZoom.disable();

--- a/src/render.js
+++ b/src/render.js
@@ -1,72 +1,85 @@
 module.exports = function render() {
-  var mapExists = this.ctx.map && this.ctx.map.getSource('mapbox-gl-draw-hot') !== undefined;
-  if (mapExists) {
-    var mode = this.ctx.events.currentModeName();
-    this.ctx.ui.setClass({
-      mode: mode
-    });
+  const store = this;
+  var mapExists = store.ctx.map && store.ctx.map.getSource('mapbox-gl-draw-hot') !== undefined;
+  if (!mapExists) return cleanup();
 
-    var newHotIds = [];
-    var newColdIds = [];
+  var mode = store.ctx.events.currentModeName();
+  store.ctx.ui.setClass({
+    mode: mode
+  });
 
-    if (this.isDirty) {
-      newColdIds = this.getAllIds();
+  var newHotIds = [];
+  var newColdIds = [];
+
+  if (store.isDirty) {
+    newColdIds = store.getAllIds();
+  }
+  else {
+    newHotIds = store.getChangedIds().filter(id => store.get(id) !== undefined);
+    newColdIds = store.sources.hot.filter(function getColdIds(geojson) {
+      return geojson.properties.id && newHotIds.indexOf(geojson.properties.id) === -1 && store.get(geojson.properties.id) !== undefined;
+    }).map(geojson => geojson.properties.id);
+  }
+
+  store.sources.hot = [];
+  let lastColdCount = store.sources.cold.length;
+  store.sources.cold = store.isDirty ? [] : store.sources.cold.filter(function saveColdFeatures(geojson) {
+    var id = geojson.properties.id || geojson.properties.parent;
+    return newHotIds.indexOf(id) === -1;
+  });
+
+  var coldChanged = lastColdCount !== store.sources.cold.length || newColdIds.length > 0;
+
+  newHotIds.concat(newColdIds).concat(newColdIds).map(function prepForViewUpdates(id) {
+    if (newHotIds.indexOf(id) > -1) {
+      return {source: 'hot', 'id': id};
     }
     else {
-      newHotIds = this.getChangedIds().filter(id => this.get(id) !== undefined);
-      newColdIds = this.sources.hot.filter(function getColdIds(geojson) {
-        return geojson.properties.id && newHotIds.indexOf(geojson.properties.id) === -1 && this.get(geojson.properties.id) !== undefined;
-      }.bind(this)).map(geojson => geojson.properties.id);
+      return {source: 'cold', 'id': id};
     }
+  }).forEach(function calculateViewUpdate(change) {
+    let {id, source} = change;
+    let feature = store.get(id);
+    let featureInternal = feature.internal(mode);
 
-    this.sources.hot = [];
-    let lastColdCount = this.sources.cold.length;
-    this.sources.cold = this.isDirty ? [] : this.sources.cold.filter(function saveColdFeatures(geojson) {
-      var id = geojson.properties.id || geojson.properties.parent;
-      return newHotIds.indexOf(id) === -1;
+    store.ctx.events.currentModeRender(featureInternal, function addGeoJsonToView(geojson) {
+      store.sources[source].push(geojson);
     });
+  });
 
-    var coldChanged = lastColdCount !== this.sources.cold.length || newColdIds.length > 0;
-
-    newHotIds.concat(newColdIds).map(function prepForViewUpdates(id) {
-      if (newHotIds.indexOf(id) > -1) {
-        return {source: 'hot', 'id': id};
-      }
-      else {
-        return {source: 'cold', 'id': id};
-      }
-    }).forEach(function calculateViewUpdate(change) {
-      let {id, source} = change;
-      let feature = this.get(id);
-      let featureInternal = feature.internal(mode);
-
-      this.ctx.events.currentModeRender(featureInternal, function addGeoJsonToView(geojson) {
-        this.sources[source].push(geojson);
-      }.bind(this));
-    }.bind(this));
-
-    if (coldChanged) {
-      this.ctx.map.getSource('mapbox-gl-draw-cold').setData({
-        type: 'FeatureCollection',
-        features: this.sources.cold
-      });
-    }
-
-    this.ctx.map.getSource('mapbox-gl-draw-hot').setData({
+  if (coldChanged) {
+    store.ctx.map.getSource('mapbox-gl-draw-cold').setData({
       type: 'FeatureCollection',
-      features: this.sources.hot
+      features: store.sources.cold
     });
-
-    let changed = this.getChangedIds().map(id => this.get(id))
-      .filter(feature => feature !== undefined)
-      .filter(feature => feature.isValid())
-      .map(feature => feature.toGeoJSON());
-
-    if (changed.length) {
-      this.ctx.map.fire('draw.changed', {features: changed});
-    }
-
   }
-  this.isDirty = false;
-  this.clearChangedIds();
+
+  store.ctx.map.getSource('mapbox-gl-draw-hot').setData({
+    type: 'FeatureCollection',
+    features: store.sources.hot
+  });
+
+  let changed = store.getChangedIds().map(id => store.get(id))
+    .filter(feature => feature !== undefined)
+    .filter(feature => feature.isValid())
+    .map(feature => feature.toGeoJSON());
+
+  if (changed.length) {
+    store.ctx.map.fire('draw.changed', {features: changed});
+  }
+
+  const flushedSelectionSets = store.flushSelected();
+  if (flushedSelectionSets.selected.length) {
+    store.ctx.map.fire('draw.select', { featureIds: flushedSelectionSets.selected });
+  }
+  if (flushedSelectionSets.deselected.length) {
+    store.ctx.map.fire('draw.deselect', { featureIds: flushedSelectionSets.deselected });
+  }
+
+  cleanup();
+
+  function cleanup() {
+    store.isDirty = false;
+    store.clearChangedIds();
+  }
 };

--- a/src/store.js
+++ b/src/store.js
@@ -165,8 +165,18 @@ Store.prototype.clearSelected = function() {
  * @return {Store} this
  */
 Store.prototype.setSelected = function(featureIds) {
-  this.clearSelected();
-  this.select(featureIds);
+  featureIds = toDenseArray(featureIds);
+
+  // Deselect any features not in the new selection
+  this.deselect(this._selectedFeatureIds.values().filter(id => {
+    return featureIds.indexOf(id) === -1;
+  }));
+
+  // Select any features in the new selection that were not already selected
+  this.select(featureIds.filter(id => {
+    return !this._selectedFeatureIds.has(id);
+  }));
+
   return this;
 };
 

--- a/src/store.js
+++ b/src/store.js
@@ -1,4 +1,5 @@
 var throttle = require('./lib/throttle');
+var toDenseArray = require('./lib/to_dense_array');
 var SimpleSet = require('./lib/simple_set');
 var render = require('./render');
 
@@ -6,6 +7,8 @@ var Store = module.exports = function(ctx) {
   this._features = {};
   this._featureIds = new SimpleSet();
   this._selectedFeatureIds = new SimpleSet();
+  this._selectedSinceLastFlush = new SimpleSet();
+  this._deselectedSinceLastFlush = new SimpleSet();
   this._changedIds = new SimpleSet();
   this.ctx = ctx;
   this.sources = {
@@ -82,19 +85,20 @@ Store.prototype.add = function(feature) {
  */
 Store.prototype.delete = function(featureIds) {
   var deleted = [];
-  [].concat(featureIds).forEach((id) => {
+  toDenseArray(featureIds).forEach(id => {
     if (!this._featureIds.has(id)) return;
-    var feature = this.get(id);
-    deleted.push(feature.toGeoJSON());
-    // Must deselect the feature as well as delete it
-    this.deselect(id);
+    deleted.push(this.get(id).toGeoJSON());
+
     delete this._features[id];
     this._featureIds.delete(id);
+    this._selectedFeatureIds.delete(id);
+    this._selectedSinceLastFlush.delete(id);
+    this._deselectedSinceLastFlush.delete(id);
   });
 
   if (deleted.length > 0) {
     this.isDirty = true;
-    this.ctx.map.fire('draw.deleted', {featureIds:deleted});
+    this.ctx.map.fire('draw.deleted', { featureIds: deleted });
   }
   return this;
 };
@@ -116,22 +120,32 @@ Store.prototype.getAll = function() {
 };
 
 /**
- * Adds a feature to the current selection.
- * @param {string} featureId
+ * Adds features to the current selection.
+ * @param {string | Array<string>} featureIds
  * @return {Store} this
  */
-Store.prototype.select = function(featureId) {
-  this._selectedFeatureIds.add(featureId);
+Store.prototype.select = function(featureIds) {
+  toDenseArray(featureIds).forEach(id => {
+    if (this._selectedFeatureIds.has(id)) return;
+    this._selectedFeatureIds.add(id);
+    this._selectedSinceLastFlush.add(id);
+    this._deselectedSinceLastFlush.delete(id);
+  });
   return this;
 };
 
 /**
- * Deletes a feature from the current selection.
- * @param {string} featureId
+ * Deletes features from the current selection.
+ * @param {string | Array<string>} featureIds
  * @return {Store} this
  */
-Store.prototype.deselect = function(featureId) {
-  this._selectedFeatureIds.delete(featureId);
+Store.prototype.deselect = function(featureIds) {
+  toDenseArray(featureIds).forEach(id => {
+    if (!this._selectedFeatureIds.has(id)) return;
+    this._selectedFeatureIds.delete(id);
+    this._selectedSinceLastFlush.delete(id);
+    this._deselectedSinceLastFlush.add(id);
+  });
   return this;
 };
 
@@ -140,7 +154,7 @@ Store.prototype.deselect = function(featureId) {
  * @return {Store} this
  */
 Store.prototype.clearSelected = function() {
-  this._selectedFeatureIds.clear();
+  this.deselect(this._selectedFeatureIds.values());
   return this;
 };
 
@@ -152,10 +166,7 @@ Store.prototype.clearSelected = function() {
  */
 Store.prototype.setSelected = function(featureIds) {
   this.clearSelected();
-  if (!featureIds) return;
-  [].concat(featureIds).forEach(id => {
-    this.select(id);
-  });
+  this.select(featureIds);
   return this;
 };
 
@@ -170,8 +181,25 @@ Store.prototype.getSelectedIds = function() {
 /**
  * Indicates whether a feature is selected.
  * @param {string} featureId
- * @return {boolean} `true` if the feature is selected, `false` if not
+ * @return {boolean} `true` if the feature is selected, `false` if not.
  */
 Store.prototype.isSelected = function(featureId) {
   return this._selectedFeatureIds.has(featureId);
+};
+
+/**
+ * Get the sets of selected and deselected
+ * feature ids since the last flush, and clear those sets.
+ *
+ * @return {Object} The flushed sets.
+ */
+Store.prototype.flushSelected = function() {
+  const wereSelected = this._selectedSinceLastFlush.values();
+  const wereDeselected = this._deselectedSinceLastFlush.values();
+  this._selectedSinceLastFlush.clear();
+  this._deselectedSinceLastFlush.clear();
+  return {
+    selected: wereSelected,
+    deselected: wereDeselected
+  };
 };

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -233,12 +233,37 @@ test('Store#delete', t => {
 
 test('Store#setSelected', t => {
   const store = createStore();
-  t.deepEqual(store.getSelectedIds(), []);
-  store.setSelected(1);
-  t.deepEqual(store.getSelectedIds(), [1]);
-  store.setSelected([3, 4]);
-  t.deepEqual(store.getSelectedIds(), [3, 4]);
+  const point = createFeature('point');
+  const line = createFeature('line');
+  const polygon = createFeature('polygon');
+
+  store.setSelected(point.id);
+  t.deepEqual(store.getSelectedIds(), [point.id]);
+  t.deepEqual(store.flushSelected(), {
+    deselected: [],
+    selected: [point.id]
+  });
+
+  store.setSelected([line.id, polygon.id]);
+  t.deepEqual(store.getSelectedIds(), [line.id, polygon.id]);
+  t.deepEqual(store.flushSelected(), {
+    deselected: [point.id],
+    selected: [line.id, polygon.id]
+  });
+
+  store.setSelected(line.id);
+  t.deepEqual(store.getSelectedIds(), [line.id]);
+  t.deepEqual(store.flushSelected(), {
+    deselected: [polygon.id],
+    selected: []
+  });
+
   store.setSelected();
   t.deepEqual(store.getSelectedIds(), []);
+  t.deepEqual(store.flushSelected(), {
+    deselected: [line.id],
+    selected: []
+  });
+
   t.end();
 });

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -2,6 +2,8 @@ import mapboxgl from 'mapbox-gl-js-mock';
 import hat from 'hat';
 import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 
+const hatRack = hat.rack();
+
 export function createMap() {
 
   var map = new mapboxgl.Map({
@@ -83,8 +85,9 @@ export const features = {
 };
 
 export function createFeature(featureType) {
-  const feature = features[featureType];
-  feature.id = hat();
+  const feature = Object.assign({
+    id: hatRack()
+  }, features[featureType]);
   feature.toGeoJSON = () => feature;
   return feature;
 }


### PR DESCRIPTION
This first commit adds `draw.select` and `draw.deselect` events so addresses #365. They are unit tested using Sinon spies on the `map.fire` function. Also fixed some things in Store based on the tests that I wrote.

Do we want to to eliminate the `draw.mode.simple_select.selected.start` events, replacing with these new events? Or keep the mode-specific events also?

I could use this PR to remove those and follow through with an event cleanup re: #367.