### PR TITLE
Add coverage script using nyc; closes #375

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,11 @@
 {
-    "presets": ["es2015"]
+  "presets": ["es2015"],
+  "env": {
+    "test": {
+      "sourceMaps": "inline",
+      "plugins": [
+        "__coverage__"
+      ]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 npm-debug.log
 .vscode/
 dist/mapbox-gl-draw.js
+coverage/
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "npm run lint && npm run tape",
     "lint": "eslint --no-eslintrc -c .eslintrc index.js src",
     "tape": "tape -r ./test/mock-browser.js -r babel-register test/*.test.js",
+    "coverage": "NODE_ENV=test nyc --reporter html npm run tape && opener coverage/index.html",
     "build": "NODE_ENV=production browserify index.js > dist/mapbox-gl-draw.js",
     "prepublish": "NODE_ENV=production browserify index.js | uglifyjs -c -m > dist/mapbox-gl-draw.js",
     "start": "node server.js"
@@ -32,8 +33,14 @@
   "bugs": {
     "url": "https://github.com/mapbox/mapbox-gl-draw/issues"
   },
+  "nyc": {
+    "sourceMap": false,
+    "instrument": false
+  },
   "devDependencies": {
+    "babel-core": "^6.9.1",
     "babel-eslint": "4.1.7",
+    "babel-plugin-__coverage__": "^11.0.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.5.2",
     "babelify": "^7.2.0",
@@ -48,6 +55,8 @@
     "mapbox-gl": "^0.19.0",
     "mapbox-gl-js-mock": "^0.22.0",
     "mock-browser": "^0.92.10",
+    "nyc": "^6.6.1",
+    "opener": "^1.4.1",
     "sinon": "^1.17.4",
     "tape": "^4.0.0",
     "uglify-js": "^2.4.23",


### PR DESCRIPTION
Now if you `npm run coverage`, it runs the tests, then open a browser showing nyc's nice report.

![screen shot 2016-06-20 at 6 14 38 pm](https://cloud.githubusercontent.com/assets/628431/16215026/225838ac-3713-11e6-8cca-88a991c8255e.png)
