### PR TITLE
Change modified event firing; closes #393

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -22,20 +22,6 @@ module.exports = function(ctx) {
   var currentMode = ModeHandler(modes.simple_select(ctx), ctx);
   var recentlyUpdatedFeatureIds = new SimpleSet();
 
-  const emitModifiedFeatures = () => {
-    ctx.store.getChangedIds().forEach(id => recentlyUpdatedFeatureIds.add(id));
-
-    let features = recentlyUpdatedFeatureIds.values().map(id => ctx.store.get(id))
-      .filter(f => f !== undefined)
-      .filter(f => f.isValid())
-      .map(f => f.toGeoJSON());
-
-    if (features.length > 0) {
-      ctx.map.fire('draw.modified', {features: features, stack: (new Error('hi')).stack});
-    }
-    recentlyUpdatedFeatureIds.clear();
-  };
-
   events.drag = function(event) {
     if (isClick(mouseDownInfo, {
       point: event.point,
@@ -89,8 +75,6 @@ module.exports = function(ctx) {
     else {
       currentMode.mouseup(event);
     }
-
-    emitModifiedFeatures();
   };
 
   events.trash = function() {
@@ -122,7 +106,6 @@ module.exports = function(ctx) {
     if (isKeyModeValid(event.keyCode)) {
       currentMode.keyup(event);
     }
-    emitModifiedFeatures();
   };
 
   events.zoomend = function() {

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -43,6 +43,12 @@ module.exports = function(ctx, opts) {
     numCoords = coordPos.length;
   };
 
+  var emitModify = () => {
+    ctx.map.fire('draw.modified', {
+      features: [feature]
+    });
+  };
+
   return {
     start: function() {
       ctx.store.setSelected(featureId);
@@ -67,6 +73,7 @@ module.exports = function(ctx, opts) {
         }
       });
       this.on('mouseup', () => true, function() {
+        if (dragging) emitModify();
         dragging = false;
         coordPos = null;
         numCoords = null;
@@ -80,6 +87,7 @@ module.exports = function(ctx, opts) {
       });
       this.on('trash', () => selectedCoordPaths.length > 0, function() {
         selectedCoordPaths.sort().reverse().forEach(id => feature.removeCoordinate(id));
+        emitModify();
         selectedCoordPaths = [];
         if (feature.isValid() === false) {
           ctx.store.delete([featureId]);

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -69,6 +69,10 @@ module.exports = function(ctx, startingSelectedIds) {
     });
   };
 
+  var emitModify = function() {
+    ctx.map.fire('draw.modified', { features });
+  };
+
   return {
     stop: function() {
       ctx.map.doubleClickZoom.enable();
@@ -168,6 +172,7 @@ module.exports = function(ctx, startingSelectedIds) {
       });
 
       this.on('mouseup', () => true, function(e) {
+        if (dragging) emitModify();
         dragging = false;
         featureCoords = null;
         features = null;


### PR DESCRIPTION
Refs #393 and #395.

This seemed to me like a straightforward way to make the `draw.modified` event more meaningful, and it addresses all the cases in https://github.com/mapbox/mapbox-gl-draw/issues/393#issuecomment-227880372: it *only* fires: 

- When you finish moving a feature.
- When you finish moving a vertex. 
- When you delete a vertex.

Tests are failing because there are some `draw.modified` event tests that want the event to fire a lot more often than it would after this modification.

What do you think @mcwhittemore , @ghoshkaj , @tmcw ?