### PR TITLE
Studio inspired fixes

### DIFF
--- a/API.md
+++ b/API.md
@@ -136,9 +136,9 @@ console.log(Draw.getAll());
 ```
 ---
 
-###`.delete(String: id) -> Draw`
+###`.delete(String | Array<String> : id) -> Draw`
 
-This method takes an id removes the coorisponding feature from Draw.
+This method takes an id or an array of ids and removes the corresponding features from Draw.
 
 In `direct_select` mode, deleting the active feature will stop the mode and revert to the `simple_select` mode.
 

--- a/API.md
+++ b/API.md
@@ -197,6 +197,10 @@ This is different from `delete` or `deleteAlll` in that it follows rules describ
 
 ---
 
+### `.getMode() -> Draw`
+
+Returns Draw's current mode. For more about the modes, see below.
+
 ### `.changeMode(String: mode, ?Object: options) -> Draw`
 
 `changeMode` triggers the mode switching process inside Draw. `mode` must be one of the below strings. Each mode takes its own options. They are described in detail below.

--- a/dist/mapbox-gl-draw.css
+++ b/dist/mapbox-gl-draw.css
@@ -60,7 +60,7 @@
   cursor: -moz-grab;
   cursor: -webkit-grab;
 }
-.mapboxgl-map.mode-direct_select.feature-vertex .mapboxgl-canvas-container.mapboxgl-interactive {
+.mapboxgl-map.mode-direct_select.feature-vertex.mouse-move .mapboxgl-canvas-container.mapboxgl-interactive {
   cursor: move;
 }
 .mapboxgl-map.mode-direct_select.feature-midpoint.mouse-pointer .mapboxgl-canvas-container.mapboxgl-interactive {

--- a/src/api.js
+++ b/src/api.js
@@ -105,7 +105,7 @@ module.exports = function(ctx) {
         ctx.store.render();
       }
     },
-    changeMode: function(mode, modeOptions) {
+    changeMode: function(mode, modeOptions = {}) {
       // Avoid changing modes just to re-select what's already selected
       if (mode === Constants.modes.SIMPLE_SELECT && this.getMode() === Constants.modes.SIMPLE_SELECT) {
         if (stringSetsAreEqual((modeOptions.featureIds || []), ctx.store.getSelectedIds())) return;

--- a/src/api.js
+++ b/src/api.js
@@ -2,6 +2,7 @@ var isEqual = require('lodash.isequal');
 var normalize = require('geojson-normalize');
 var hat = require('hat');
 var featuresAt = require('./lib/features_at');
+var stringSetsAreEqual = require('./lib/string_sets_are_equal');
 var geojsonhint = require('geojsonhint');
 var Constants = require('./constants');
 
@@ -23,6 +24,15 @@ module.exports = function(ctx) {
     },
     getSelectedIds: function () {
       return ctx.store.getSelectedIds();
+    },
+    setSelected: function(idsToSelect) {
+      if (stringSetsAreEqual(idsToSelect, ctx.store.getSelectedIds())) return;
+      if (this.getMode() !== Constants.modes.SIMPLE_SELECT) {
+        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: idsToSelect }, { silent: true });
+      } else {
+        ctx.store.setSelected(idsToSelect, { silent: true });
+        ctx.store.render();
+      }
     },
     set: function(featureCollection) {
       if (featureCollection.type === undefined || featureCollection.type !== 'FeatureCollection' || !Array.isArray(featureCollection.features)) {
@@ -98,14 +108,6 @@ module.exports = function(ctx) {
     },
     getMode: function() {
       return ctx.events.getMode();
-    },
-    setSelected: function(featureIds) {
-      if (this.getMode() === Constants.modes.SIMPLE_SELECT) {
-        ctx.store.setSelected(featureIds, { silent: true });
-      } else {
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds }, { silent: true });
-      }
-      ctx.store.render();
     },
     trash: function() {
       ctx.events.trash({ silent: true });

--- a/src/api.js
+++ b/src/api.js
@@ -87,14 +87,25 @@ module.exports = function(ctx) {
     },
     delete: function(featureIds) {
       ctx.store.delete(featureIds, { silent: true });
-      ctx.store.render();
+      // If we were in direct select mode and our selected feature no longer exists
+      // (because it was deleted), we need to get out of that mode.
+      if (this.getMode() === Constants.modes.DIRECT_SELECT && !ctx.store.getSelectedIds().length) {
+        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent: true });
+      } else {
+        ctx.store.render();
+      }
     },
     deleteAll: function() {
       ctx.store.delete(ctx.store.getAllIds(), { silent: true });
-      ctx.store.render();
+      // If we were in direct select mode, now our selected feature no longer exists,
+      // so escape that mode.
+      if (this.getMode() === Constants.modes.DIRECT_SELECT) {
+        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent: true });
+      } else {
+        ctx.store.render();
+      }
     },
     changeMode: function(mode, modeOptions) {
-      console.error(`changing mode to ${mode}`)
       // Avoid changing modes just to re-select what's already selected
       if (mode === Constants.modes.SIMPLE_SELECT && this.getMode() === Constants.modes.SIMPLE_SELECT) {
         if (stringSetsAreEqual((modeOptions.featureIds || []), ctx.store.getSelectedIds())) return;

--- a/src/api.js
+++ b/src/api.js
@@ -94,8 +94,8 @@ module.exports = function(ctx) {
         features: ctx.store.getAll().map(feature => feature.toGeoJSON())
       };
     },
-    delete: function(id) {
-      ctx.store.delete([id], { silent: true });
+    delete: function(featureIds) {
+      ctx.store.delete(featureIds, { silent: true });
       ctx.store.render();
     },
     deleteAll: function() {

--- a/src/api.js
+++ b/src/api.js
@@ -39,6 +39,8 @@ module.exports = function(ctx) {
         return newIdsForFasterLookUp[id] === undefined;
       });
       ctx.store.delete(toDelete);
+
+      ctx.store.render();
       return newIds;
     },
     add: function (geojson) {

--- a/src/api.js
+++ b/src/api.js
@@ -3,6 +3,7 @@ var normalize = require('geojson-normalize');
 var hat = require('hat');
 var featuresAt = require('./lib/features_at');
 var geojsonhint = require('geojsonhint');
+var Constants = require('./constants');
 
 var featureTypes = {
   'Polygon': require('./feature_types/polygon'),
@@ -97,6 +98,14 @@ module.exports = function(ctx) {
     },
     getMode: function() {
       return ctx.events.getMode();
+    },
+    setSelected: function(featureIds) {
+      if (this.getMode() === Constants.modes.SIMPLE_SELECT) {
+        ctx.store.setSelected(featureIds, { silent: true });
+      } else {
+        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds }, { silent: true });
+      }
+      ctx.store.render();
     },
     trash: function() {
       ctx.events.trash({ silent: true });

--- a/src/api.js
+++ b/src/api.js
@@ -95,6 +95,9 @@ module.exports = function(ctx) {
     changeMode: function(mode, modeOptions) {
       ctx.events.changeMode(mode, modeOptions, { silent: true });
     },
+    getMode: function() {
+      return ctx.events.getMode();
+    },
     trash: function() {
       ctx.events.trash({ silent: true });
     }

--- a/src/api.js
+++ b/src/api.js
@@ -49,9 +49,8 @@ module.exports = function(ctx) {
       toDelete = toDelete.filter(id => {
         return newIdsForFasterLookUp[id] === undefined;
       });
-      ctx.store.delete(toDelete);
+      this.delete(toDelete);
 
-      ctx.store.render();
       return newIds;
     },
     add: function (geojson) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,8 +5,6 @@ module.exports = {
   CONTROL_BUTTON_POINT_CLASS: 'mapbox-gl-draw_point',
   CONTROL_BUTTON_TRASH_CLASS: 'mapbox-gl-draw_trash',
   CONTROL_GROUP_CLASS: 'mapboxgl-ctrl-group',
-  MOUSE_ADD_CLASS_FRAGMENT: 'add',
-  MOUSE_MOVE_CLASS_FRAGMENT: 'move',
   ATTRIBUTION_CLASS: 'mapboxgl-ctrl-attrib',
   ACTIVE_BUTTON_CLASS: 'active',
   cursors: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,13 @@ module.exports = {
   MOUSE_MOVE_CLASS_FRAGMENT: 'move',
   ATTRIBUTION_CLASS: 'mapboxgl-ctrl-attrib',
   ACTIVE_BUTTON_CLASS: 'active',
+  cursors: {
+    ADD: 'add',
+    MOVE: 'move',
+    DRAG: 'drag',
+    POINTER: 'pointer',
+    NONE: 'none'
+  },
   types: {
     POLYGON: 'polygon',
     LINE: 'line_string',

--- a/src/events.js
+++ b/src/events.js
@@ -1,5 +1,5 @@
 var ModeHandler = require('./lib/mode_handler');
-var getFeatureAtAndSetCursors = require('./lib/get_features_and_set_cursor');
+var getFeaturesAndSetCursor = require('./lib/get_features_and_set_cursor');
 var isClick = require('./lib/is_click');
 var Constants = require('./constants');
 
@@ -36,13 +36,11 @@ module.exports = function(ctx) {
 
   events.mousemove = function(event) {
     if (mouseDownInfo.isDown) {
-      events.drag(event);
+      return events.drag(event);
     }
-    else {
-      var target = getFeatureAtAndSetCursors(event, ctx);
-      event.featureTarget = target;
-      currentMode.mousemove(event);
-    }
+    var target = getFeaturesAndSetCursor(event, ctx);
+    event.featureTarget = target;
+    currentMode.mousemove(event);
   };
 
   events.mousedown = function(event) {
@@ -51,14 +49,14 @@ module.exports = function(ctx) {
       time: new Date().getTime(),
       point: event.point
     };
-    var target = getFeatureAtAndSetCursors(event, ctx);
+    var target = getFeaturesAndSetCursor(event, ctx);
     event.featureTarget = target;
     currentMode.mousedown(event);
   };
 
   events.mouseup = function(event) {
     mouseDownInfo.isDown = false;
-    var target = getFeatureAtAndSetCursors(event, ctx);
+    var target = getFeaturesAndSetCursor(event, ctx);
     event.featureTarget = target;
 
     if (isClick(mouseDownInfo, {

--- a/src/events.js
+++ b/src/events.js
@@ -161,6 +161,9 @@ module.exports = function(ctx) {
     },
     trash: function(options) {
       currentMode.trash(options);
+    },
+    getMode: function() {
+      return currentModeName;
     }
   };
 

--- a/src/events.js
+++ b/src/events.js
@@ -29,7 +29,7 @@ module.exports = function(ctx) {
       event.originalEvent.stopPropagation();
     }
     else {
-      ctx.ui.queueMapClasses({mouse: 'drag'});
+      ctx.ui.queueMapClasses({ mouse: Constants.cursors.DRAG });
       currentMode.drag(event);
     }
   };

--- a/src/lib/common_selectors.js
+++ b/src/lib/common_selectors.js
@@ -7,13 +7,9 @@ module.exports = {
       return featureTarget.properties.meta === type;
     };
   },
-  isBoxSelecting(e) {
-    if (!e.originalEvent) {
-      return false;
-    }
-    if (!e.originalEvent.shiftKey) {
-      return false;
-    }
+  isShiftMousedown(e) {
+    if (!e.originalEvent) return false;
+    if (!e.originalEvent.shiftKey) return false;
     return e.originalEvent.button === 0;
   },
   isActiveFeature: function(e) {

--- a/src/lib/double_click_zoom.js
+++ b/src/lib/double_click_zoom.js
@@ -2,14 +2,12 @@ module.exports = {
   enable(ctx) {
     setTimeout(() => {
       if (!ctx.map || !ctx.map.doubleClickZoom) return;
-      if (ctx.map.doubleClickZoom.isEnabled()) return;
       ctx.map.doubleClickZoom.enable();
     }, 0);
   },
   disable(ctx) {
     setTimeout(() => {
       if (!ctx.map || !ctx.map.doubleClickZoom) return;
-      if (!ctx.map.doubleClickZoom.isEnabled()) return;
       ctx.map.doubleClickZoom.disable();
     }, 0);
   }

--- a/src/lib/double_click_zoom.js
+++ b/src/lib/double_click_zoom.js
@@ -1,0 +1,16 @@
+module.exports = {
+  enable(ctx) {
+    setTimeout(() => {
+      console.error('enabling')
+      if (!ctx.map || !ctx.map.doubleClickZoom) return;
+      ctx.map.doubleClickZoom.enable();
+    }, 0);
+  },
+  disable(ctx) {
+    setTimeout(() => {
+      console.error('disabling')
+      if (!ctx.map || !ctx.map.doubleClickZoom) return;
+      ctx.map.doubleClickZoom.disable();
+    }, 0);
+  }
+};

--- a/src/lib/double_click_zoom.js
+++ b/src/lib/double_click_zoom.js
@@ -1,15 +1,15 @@
 module.exports = {
   enable(ctx) {
     setTimeout(() => {
-      console.error('enabling')
       if (!ctx.map || !ctx.map.doubleClickZoom) return;
+      if (ctx.map.doubleClickZoom.isEnabled()) return;
       ctx.map.doubleClickZoom.enable();
     }, 0);
   },
   disable(ctx) {
     setTimeout(() => {
-      console.error('disabling')
       if (!ctx.map || !ctx.map.doubleClickZoom) return;
+      if (!ctx.map.doubleClickZoom.isEnabled()) return;
       ctx.map.doubleClickZoom.disable();
     }, 0);
   }

--- a/src/lib/get_features_and_set_cursor.js
+++ b/src/lib/get_features_and_set_cursor.js
@@ -1,19 +1,23 @@
 var featuresAt = require('./features_at');
+var Constants = require('../constants');
 
 module.exports = function getFeatureAtAndSetCursors(event, ctx) {
   var features = featuresAt(event, null, ctx);
-  var classes = { mouse: 'none' };
+  var classes = { mouse: Constants.cursors.NONE };
 
   if (features[0]) {
-    classes.mouse = features[0].properties.active === 'true' ? 'move' : 'pointer';
+    classes.mouse = features[0].properties.active === 'true'
+      ? Constants.cursors.MOVE
+      : Constants.cursors.POINTER;
     classes.feature = features[0].properties.meta;
   }
 
-  if (ctx.events.currentModeName().includes('draw')) {
-    classes.mouse = 'add';
+  if (ctx.events.currentModeName().indexOf('draw') !== -1) {
+    classes.mouse = Constants.cursors.ADD;
   }
 
   ctx.ui.queueMapClasses(classes);
+  ctx.ui.updateMapClasses();
 
   return features[0];
 };

--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -37,15 +37,18 @@ var ModeHandler = function(mode, DrawContext) {
   var delegate = function (eventName, event) {
     var handles = handlers[eventName];
     var iHandle = handles.length;
+    var handlerCalled = false;
     while (iHandle--) {
       var handle = handles[iHandle];
       if (handle.selector(event)) {
         handle.fn.call(ctx, event);
-        DrawContext.store.render();
-        break;
+        handlerCalled = true;
       }
     }
-    DrawContext.ui.updateMapClasses();
+    if (handlerCalled) {
+      DrawContext.store.render();
+      DrawContext.ui.updateMapClasses();
+    }
   };
 
   mode.start.call(ctx);

--- a/src/lib/string_sets_are_equal.js
+++ b/src/lib/string_sets_are_equal.js
@@ -1,0 +1,3 @@
+module.exports = function(a, b) {
+  return JSON.stringify(a.sort()) === JSON.stringify(b.sort());
+};

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -97,10 +97,10 @@ module.exports = function(ctx, opts) {
         stopDragging();
       });
       this.on('click', noFeature, function() {
-        ctx.events.changeMode('simple_select');
+        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
       });
       this.on('click', isInactiveFeature, function() {
-        ctx.events.changeMode('simple_select');
+        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
       });
     },
     stop: function() {
@@ -123,7 +123,7 @@ module.exports = function(ctx, opts) {
     },
     trash: function() {
       if (selectedCoordPaths.length === 0) {
-        return ctx.events.changeMode('simple_select', { features: [feature] });
+        return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { features: [feature] });
       }
 
       selectedCoordPaths.sort().reverse().forEach(id => feature.removeCoordinate(id));
@@ -134,7 +134,7 @@ module.exports = function(ctx, opts) {
       selectedCoordPaths = [];
       if (feature.isValid() === false) {
         ctx.store.delete([featureId]);
-        ctx.events.changeMode('simple_select', null);
+        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, null);
       }
     }
   };

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -1,5 +1,6 @@
 var {noFeature, isOfMetaType, isInactiveFeature, isShiftDown} = require('../lib/common_selectors');
 var createSupplementaryPoints = require('../lib/create_supplementary_points');
+const doubleClickZoom = require('../lib/double_click_zoom');
 const Constants = require('../constants');
 
 module.exports = function(ctx, opts) {
@@ -62,7 +63,7 @@ module.exports = function(ctx, opts) {
       dragging = false;
       canDragMove = false;
       ctx.store.setSelected(featureId);
-      ctx.map.doubleClickZoom.disable();
+      doubleClickZoom.disable(ctx);
       this.on('mousedown', isOfMetaType('vertex'), onVertex);
       this.on('mousedown', isOfMetaType('midpoint'), onMidpoint);
       this.on('drag', () => canDragMove, function(e) {
@@ -103,7 +104,7 @@ module.exports = function(ctx, opts) {
       });
     },
     stop: function() {
-      ctx.map.doubleClickZoom.enable();
+      doubleClickZoom.enable(ctx);
     },
     render: function(geojson, push) {
       if (featureId === geojson.properties.id) {

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -49,7 +49,6 @@ module.exports = function(ctx) {
         features: [line.toGeoJSON()]
       });
     }
-    ctx.ui.queueMapClasses({ mouse: Constants.cursors.NONE });
     ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [line.id] });
   }
 

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -20,8 +20,8 @@ module.exports = function(ctx) {
   ctx.store.add(line);
 
   function stopDrawingAndRemove() {
-    ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
     ctx.store.delete([line.id], { silent: true });
+    ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
   }
 
   function handleMouseMove(e) {
@@ -43,9 +43,9 @@ module.exports = function(ctx) {
   }
 
   function finish() {
+    if (!line.isValid()) return stopDrawingAndRemove();
     line.removeCoordinate(`${currentVertexPosition}`);
     currentVertexPosition--;
-    if (!line.isValid()) return stopDrawingAndRemove();
     ctx.map.fire(Constants.events.CREATE, {
       features: [line.toGeoJSON()]
     });

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -29,6 +29,7 @@ module.exports = function(ctx) {
   }
 
   function handleClick(e) {
+    ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
     // Finish if we clicked on the first or last point
     if (currentVertexPosition > 0 &&
       (isEventAtCoordinates(e, line.coordinates[0]) || isEventAtCoordinates(e, line.coordinates[currentVertexPosition - 1]))
@@ -48,6 +49,7 @@ module.exports = function(ctx) {
         features: [line.toGeoJSON()]
       });
     }
+    ctx.ui.queueMapClasses({ mouse: Constants.cursors.NONE });
     ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [line.id] });
   }
 
@@ -59,7 +61,7 @@ module.exports = function(ctx) {
           ctx.map.doubleClickZoom.disable();
         }
       });
-      ctx.ui.queueMapClasses({ mouse: Constants.MOUSE_ADD_CLASS_FRAGMENT });
+      ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
       ctx.ui.setActiveButton(Constants.types.LINE);
       this.on('mousemove', CommonSelectors.true, handleMouseMove);
       this.on('click', CommonSelectors.true, handleClick);

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -23,7 +23,7 @@ module.exports = function(ctx) {
   }
 
   function handleClick(e) {
-    ctx.ui.queueMapClasses({ mouse: Constants.MOUSE_MOVE_CLASS_FRAGMENT });
+    ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
     point.updateCoordinate('', e.lngLat.lng, e.lngLat.lat);
     ctx.map.fire(Constants.events.CREATE, {
       features: [point.toGeoJSON()]
@@ -34,7 +34,7 @@ module.exports = function(ctx) {
   return {
     start() {
       ctx.store.clearSelected();
-      ctx.ui.queueMapClasses({ mouse: Constants.MOUSE_ADD_CLASS_FRAGMENT });
+      ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
       ctx.ui.setActiveButton(Constants.types.POINT);
       this.on('click', CommonSelectors.true, handleClick);
       this.on('keyup', CommonSelectors.isEscapeKey, stopDrawingAndRemove);

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -21,8 +21,8 @@ module.exports = function(ctx) {
   ctx.store.add(polygon);
 
   function stopDrawingAndRemove() {
-    ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
     ctx.store.delete([polygon.id], { silent: true });
+    ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
   }
 
   function handleMouseMove(e) {
@@ -41,9 +41,9 @@ module.exports = function(ctx) {
   }
 
   function finish() {
+    if (!polygon.isValid()) return stopDrawingAndRemove();
     polygon.removeCoordinate(`0.${currentVertexPosition}`);
     currentVertexPosition--;
-    if (!polygon.isValid()) return stopDrawingAndRemove();
     ctx.map.fire(Constants.events.CREATE, {
       features: [polygon.toGeoJSON()]
     });

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -29,6 +29,7 @@ module.exports = function(ctx) {
   }
 
   function handleClick(e) {
+    ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
     // Finish if we clicked on the first or last point
     if (currentVertexPosition > 0 &&
       (isEventAtCoordinates(e, polygon.coordinates[0][0]) || isEventAtCoordinates(e, polygon.coordinates[0][currentVertexPosition - 1]))
@@ -57,7 +58,7 @@ module.exports = function(ctx) {
           ctx.map.doubleClickZoom.disable();
         }
       }, 0);
-      ctx.ui.queueMapClasses({ mouse: Constants.MOUSE_ADD_CLASS_FRAGMENT });
+      ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
       ctx.ui.setActiveButton(Constants.types.POLYGON);
       this.on('mousemove', CommonSelectors.true, handleMouseMove);
       this.on('click', CommonSelectors.true, handleClick);

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -119,6 +119,7 @@ module.exports = function(ctx, options = {}) {
       this.on('mousedown', isActiveFeature, function(e) {
         canDragMove = true;
         startPos = e.lngLat;
+        this.render(e.featureTarget.properties.id);
       });
 
       this.on('click', isFeature, function(e) {

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -30,8 +30,6 @@ module.exports = function(ctx, options = {}) {
   }
 
   var cleanupBoxSelect = function() {
-    dragging = false;
-    canDragMove = false;
     boxSelecting = false;
     setTimeout(() => {
       ctx.map.dragPan.enable();
@@ -82,8 +80,10 @@ module.exports = function(ctx, options = {}) {
       // probably passed in from a `draw_*` mode
       if (ctx.store) ctx.store.setSelected(initiallySelectedFeatureIds);
 
-      // Any click should stop box selecting and dragging
-      this.on('click', () => true, function() {
+      // Any mouseup should stop box selecting and dragging
+      this.on('mouseup', () => true, function() {
+        dragging = false;
+        canDragMove = false;
         if (boxSelecting) {
           cleanupBoxSelect();
         }
@@ -118,9 +118,9 @@ module.exports = function(ctx, options = {}) {
       }
 
       this.on('mousedown', isActiveFeature, function(e) {
+        this.render(e.featureTarget.properties.id);
         canDragMove = true;
         startPos = e.lngLat;
-        this.render(e.featureTarget.properties.id);
       });
 
       this.on('click', isFeature, function(e) {

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -52,7 +52,7 @@ module.exports = function(ctx, options = {}) {
         ids.forEach(id => {
           context.render(id);
         });
-        ctx.ui.queueMapClasses({mouse:'move'});
+        ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
       }
     }
     cleanupBoxSelect();
@@ -105,7 +105,7 @@ module.exports = function(ctx, options = {}) {
           coordPath: e.featureTarget.properties.coord_path,
           startPos: e.lngLat
         });
-        ctx.ui.queueMapClasses({mouse:'move'});
+        ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
       });
 
       if (ctx.options.boxSelect) {
@@ -132,7 +132,7 @@ module.exports = function(ctx, options = {}) {
         }
         else if (ctx.store.isSelected(id) && isShiftDown(e)) {
           ctx.store.deselect(id);
-          ctx.ui.queueMapClasses({mouse:'pointer'});
+          ctx.ui.queueMapClasses({ mouse: Constants.cursors.POINTER });
           this.render(id);
           if (featureIds.length === 1 ) {
             ctx.map.doubleClickZoom.enable();
@@ -141,20 +141,20 @@ module.exports = function(ctx, options = {}) {
         else if (!ctx.store.isSelected(id) && isShiftDown(e)) {
           // add to selected
           ctx.store.select(id);
-          ctx.ui.queueMapClasses({mouse:'move'});
+          ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
           this.render(id);
         }
         else if (!ctx.store.isSelected(id) && !isShiftDown(e)) {
           // make selected
           featureIds.forEach(formerId => this.render(formerId));
           ctx.store.setSelected(id);
-          ctx.ui.queueMapClasses({mouse:'move'});
+          ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
           this.render(id);
         }
       });
 
       this.on('drag', () => boxSelecting, function(e) {
-        ctx.ui.queueMapClasses({mouse:'add'});
+        ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
         if (!box) {
           box = document.createElement('div');
           box.classList.add('mapbox-gl-draw_boxselect');

--- a/src/render.js
+++ b/src/render.js
@@ -7,13 +7,6 @@ module.exports = function render() {
 
   var mode = store.ctx.events.currentModeName();
 
-  // If we were in direct select mode and our selected feature no longer exists
-  // (because it was deleted), we need to get out of that mode.
-  if (mode === Constants.modes.DIRECT_SELECT && !store.get(store.getSelectedIds()[0])) {
-    // The mode change should cause a re-render
-    return store.ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
-  }
-
   store.ctx.ui.queueMapClasses({ mode });
 
   var newHotIds = [];

--- a/src/render.js
+++ b/src/render.js
@@ -6,9 +6,15 @@ module.exports = function render() {
   if (!mapExists) return cleanup();
 
   var mode = store.ctx.events.currentModeName();
-  store.ctx.ui.queueMapClasses({
-    mode: mode
-  });
+
+  // If we were in direct select mode and our selected feature no longer exists
+  // (because it was deleted), we need to get out of that mode.
+  if (mode === Constants.modes.DIRECT_SELECT && !store.get(store.getSelectedIds()[0])) {
+    // The mode change should cause a re-render
+    return store.ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
+  }
+
+  store.ctx.ui.queueMapClasses({ mode });
 
   var newHotIds = [];
   var newColdIds = [];

--- a/src/store.js
+++ b/src/store.js
@@ -131,6 +131,7 @@ Store.prototype.select = function(featureIds, options = {}) {
   toDenseArray(featureIds).forEach(id => {
     if (this._selectedFeatureIds.has(id)) return;
     this._selectedFeatureIds.add(id);
+    this._changedFeatureIds.add(id);
     if (!options.silent) {
       this._emitSelectionChange = true;
     }
@@ -149,6 +150,7 @@ Store.prototype.deselect = function(featureIds, options = {}) {
   toDenseArray(featureIds).forEach(id => {
     if (!this._selectedFeatureIds.has(id)) return;
     this._selectedFeatureIds.delete(id);
+    this._changedFeatureIds.add(id);
     if (!options.silent) {
       this._emitSelectionChange = true;
     }

--- a/src/store.js
+++ b/src/store.js
@@ -7,7 +7,7 @@ var Store = module.exports = function(ctx) {
   this._features = {};
   this._featureIds = new StringSet();
   this._selectedFeatureIds = new StringSet();
-  this._changedFeatureIds = [];
+  this._changedFeatureIds = new StringSet();
   this._deletedFeaturesToEmit = [];
   this._emitSelectionChange = false;
   this.ctx = ctx;
@@ -34,9 +34,7 @@ Store.prototype.setDirty = function() {
  * @return {Store} this
  */
 Store.prototype.featureChanged = function(featureId) {
-  if (this._changedFeatureIds.indexOf(featureId) === -1) {
-    this._changedFeatureIds.push(featureId);
-  }
+  this._changedFeatureIds.add(featureId);
   return this;
 };
 
@@ -45,7 +43,7 @@ Store.prototype.featureChanged = function(featureId) {
  * @return {Store} this
  */
 Store.prototype.getChangedIds = function() {
-  return this._changedFeatureIds;
+  return this._changedFeatureIds.values();
 };
 
 /**
@@ -53,7 +51,7 @@ Store.prototype.getChangedIds = function() {
  * @return {Store} this
  */
 Store.prototype.clearChangedIds = function() {
-  this._changedFeatureIds = [];
+  this._changedFeatureIds.clear();
   return this;
 };
 

--- a/test/common_selectors.test.js
+++ b/test/common_selectors.test.js
@@ -23,29 +23,29 @@ test('commonSelectors.isOfMetaType', t => {
   t.end();
 });
 
-test('commonSelectors.isBoxSelecting', t => {
-  t.ok(commonSelectors.isBoxSelecting({
+test('commonSelectors.isShiftMousedown', t => {
+  t.ok(commonSelectors.isShiftMousedown({
     originalEvent: {
       shiftKey: true,
       button: 0
     }
   }));
 
-  t.notOk(commonSelectors.isBoxSelecting({
+  t.notOk(commonSelectors.isShiftMousedown({
     originalEvent: {
       shiftKey: false,
       button: 0
     }
   }));
 
-  t.notOk(commonSelectors.isBoxSelecting({
+  t.notOk(commonSelectors.isShiftMousedown({
     originalEvent: {
       shiftKey: true,
       button: 1
     }
   }));
 
-  t.notOk(commonSelectors.isBoxSelecting({
+  t.notOk(commonSelectors.isShiftMousedown({
     nothing: false
   }));
 

--- a/test/draw_line_string.test.js
+++ b/test/draw_line_string.test.js
@@ -1,5 +1,4 @@
 import test from 'tape';
-import mapboxgl from 'mapbox-gl-js-mock';
 import createSyntheticEvent from 'synthetic-dom-events';
 import GLDraw from '../';
 import click from './utils/mouse_click';

--- a/test/interaction_events.test.js
+++ b/test/interaction_events.test.js
@@ -747,14 +747,10 @@ function runTests() {
     afterNextRender(() => {
       Draw.trash();
       afterNextRender(() => {
-        firedWith(t, 'draw.selectionchange', {
-          features: [line]
-        });
         firedWith(t, 'draw.delete', {
           features: [line]
         });
         t.deepEqual(flushDrawEvents(), [
-          'draw.selectionchange',
           'draw.delete'
         ], 'no unexpected draw events');
         t.end();

--- a/test/simple_select.test.js
+++ b/test/simple_select.test.js
@@ -24,9 +24,7 @@ test('simple_select', t => {
   var cleanUp = function(cb) {
     Draw.deleteAll();
     map.fire.reset();
-    if (cb) {
-      afterNextRender(cb);
-    }
+    if (cb) cb();
   };
 
   var getFireArgs = function() {
@@ -75,7 +73,7 @@ test('simple_select', t => {
             t.equal(args[0][1].features.length, 1, 'should have one feature selected');
             t.equal(args[0][1].features[0].id, id, 'should be the feature we expect to be selected');
           }
-          cleanUp(() => t.end());
+          cleanUp(t.end);
         });
       });
     });
@@ -105,7 +103,7 @@ test('simple_select', t => {
         if (args.length > 0) {
           t.equal(args[0][1].features.length, ids.length, 'should have all features selected');
         }
-        cleanUp(() => t.end());
+        cleanUp(t.end);
       });
     });
   });
@@ -122,7 +120,7 @@ test('simple_select', t => {
 
       afterNextRender(() => {
         t.equal(getFireArgs().filter(arg => arg[0] === 'draw.selectionchange').length, 0, 'there should be no draw.selectionchange event');
-        cleanUp(() => t.end());
+        cleanUp(t.end);
       });
     });
   });
@@ -142,7 +140,7 @@ test('simple_select', t => {
         if (args.length > 0) {
           t.equal(args[0][1].features.length, 0, 'should have no features selected');
         }
-        cleanUp(() => t.end());
+        cleanUp(t.end);
       });
     });
   });
@@ -166,7 +164,7 @@ test('simple_select', t => {
           t.equal(args[0][1].features.length, 1, 'should have only one feature selected');
           t.equal(args[0][1].features[0].id, id, 'should be the feature we expect to be selected');
         }
-        cleanUp(() => t.end());
+        cleanUp(t.end);
       });
     });
   });
@@ -190,7 +188,7 @@ test('simple_select', t => {
         if (args.length > 0) {
           t.equal(args[0][1].features.length, 0, 'should have no features selected');
         }
-        cleanUp(() => t.end());
+        cleanUp(t.end);
       });
     });
   });
@@ -209,7 +207,7 @@ test('simple_select', t => {
 
       var selectedFeatures = Draw.getSelectedIds();
       t.equal(selectedFeatures.length, 0, 'nothing should be selected anymore');
-      cleanUp(() => t.end());
+      cleanUp(t.end);
     });
   });
 
@@ -235,7 +233,7 @@ test('simple_select', t => {
         if (args.length > 0) {
           t.equal(args[0][1].mode, 'direct_select', 'should change to direct select');
         }
-        cleanUp(() => t.end());
+        cleanUp(t.end);
       });
     });
   });
@@ -260,7 +258,7 @@ test('simple_select', t => {
         if (args.length > 0) {
           t.equal(args[0][1].mode, 'direct_select', 'should change to direct select');
         }
-        cleanUp(() => t.end());
+        cleanUp(t.end);
       });
     });
   });
@@ -287,7 +285,7 @@ test('simple_select', t => {
           t.equal(args[0][1].features[0].id, pointId, 'selection includes point');
           t.equal(args[0][1].features[1].id, id, 'selection includes polygon');
         }
-        cleanUp(() => t.end());
+        cleanUp(t.end);
       });
     });
   });
@@ -313,7 +311,7 @@ test('simple_select', t => {
           t.equal(args[0][1].features.length, 1, 'should have only one feature selected');
           t.equal(args[0][1].features[0].id, id, 'should be the feature we expect to be selected');
         }
-        cleanUp(() => t.end());
+        cleanUp(t.end);
       });
     });
   });

--- a/test/utils/after_next_render.js
+++ b/test/utils/after_next_render.js
@@ -2,14 +2,14 @@ export default function(map) {
   var render = 0;
   map.on('draw.render', function() {
     render++;
-  })
+  });
   return function(cb) {
     var lastRender = render;
-   var id = setInterval(function() {
-    if (lastRender < render) {
-      clearInterval(id);
-      cb();
-    }
-   });
-  }
+    var id = setInterval(function() {
+      if (lastRender < render) {
+        clearInterval(id);
+        cb();
+      }
+    });
+  };
 }


### PR DESCRIPTION
- Add `Draw.getMode()` API function, so Studio could tell if it needed to update Draw's mode.
- Make `Draw.set()` re-render when it's done deleting.
- Prevent box selecting from happening because you shift+double-clicked to zoom out
- Exit `direct_select` mode if the selected feature has been deleted
- Add `Draw.setSelected()` to API as a preferable way to select items programmatically, instead of needing to change mode to `simple_select` and specifying features.
- Fix cursors so the right ones show and they change as the mouse moves.
- Fix this: create a feature, then before deselecting it try to drag it — it's like the browser tries to treat it as a file that you're dragging and dropping. Fixed by re-rendering the feature when you mousedown on it.

Might accumulate more ...