### PR TITLE
Cleanup and extend API tests

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -5,6 +5,7 @@ var featuresAt = require('./lib/features_at');
 var stringSetsAreEqual = require('./lib/string_sets_are_equal');
 var geojsonhint = require('geojsonhint');
 var Constants = require('./constants');
+var StringSet = require('./lib/string_set');
 
 var featureTypes = {
   'Polygon': require('./feature_types/polygon'),
@@ -16,123 +17,139 @@ var featureTypes = {
 };
 
 module.exports = function(ctx) {
+  const api = {};
 
-  return {
-    getFeatureIdsAt: function(point) {
-      var features = featuresAt({point}, null, ctx);
-      return features.map(feature => feature.properties.id);
-    },
-    getSelectedIds: function () {
-      return ctx.store.getSelectedIds();
-    },
-    set: function(featureCollection) {
-      if (featureCollection.type === undefined || featureCollection.type !== 'FeatureCollection' || !Array.isArray(featureCollection.features)) {
-        throw new Error('Invalid FeatureCollection');
+  api.getFeatureIdsAt = function(point) {
+    var features = featuresAt({ point }, null, ctx);
+    return features.map(feature => feature.properties.id);
+  };
+
+  api.getSelectedIds = function () {
+    return ctx.store.getSelectedIds();
+  };
+
+  api.set = function(featureCollection) {
+    if (featureCollection.type === undefined || featureCollection.type !== 'FeatureCollection' || !Array.isArray(featureCollection.features)) {
+      throw new Error('Invalid FeatureCollection');
+    }
+    var toDelete = ctx.store.getAllIds().slice();
+    var newIds = api.add(featureCollection);
+    var newIdsLookup = new StringSet(newIds);
+
+    toDelete = toDelete.filter(id => !newIdsLookup.has(id));
+    if (toDelete.length) {
+      api.delete(toDelete);
+    }
+
+    return newIds;
+  };
+
+  api.add = function (geojson) {
+    var featureCollection = normalize(geojson);
+    var errors = geojsonhint.hint(featureCollection);
+    if (errors.length) {
+      throw new Error(errors[0].message);
+    }
+    featureCollection = JSON.parse(JSON.stringify(featureCollection));
+
+    var ids = featureCollection.features.map(feature => {
+      feature.id = feature.id || hat();
+
+      if (feature.geometry === null) {
+        throw new Error('Invalid geometry: null');
       }
-      var toDelete = ctx.store.getAllIds().slice(0);
-      var newIds = this.add(featureCollection);
 
-      var newIdsForFasterLookUp = {};
-      for (var i = 0; i < newIds.length; i++) {
-        newIdsForFasterLookUp[newIds[i]] = 0;
-      }
-
-      toDelete = toDelete.filter(id => {
-        return newIdsForFasterLookUp[id] === undefined;
-      });
-      this.delete(toDelete);
-
-      return newIds;
-    },
-    add: function (geojson) {
-      var featureCollection = normalize(geojson);
-      var errors = geojsonhint.hint(featureCollection);
-      if (errors.length) {
-        throw new Error(errors[0].message);
-      }
-      featureCollection = JSON.parse(JSON.stringify(featureCollection));
-
-      var ids = featureCollection.features.map(feature => {
-        feature.id = feature.id || hat();
-
-        if (feature.geometry === null) {
-          throw new Error('Invalid geometry: null');
+      if (ctx.store.get(feature.id) === undefined || ctx.store.get(feature.id).type !== feature.geometry.type) {
+        // If the feature has not yet been created ...
+        var model = featureTypes[feature.geometry.type];
+        if (model === undefined) {
+          throw new Error(`Invalid geometry type: ${feature.geometry.type}.`);
         }
-
-        if (ctx.store.get(feature.id) === undefined || ctx.store.get(feature.id).type !== feature.geometry.type) {
-          var model = featureTypes[feature.geometry.type];
-          if (model === undefined) {
-            throw new Error(`Invalid geometry type: ${feature.geometry.type}.`);
-          }
-          let internalFeature = new model(ctx, feature);
-          ctx.store.add(internalFeature);
-        }
-        else {
-          let internalFeature = ctx.store.get(feature.id);
-          internalFeature.properties = feature.properties;
-          if (!isEqual(internalFeature.getCoordinates(), feature.geometry.coordinates)) {
-            internalFeature.incomingCoords(feature.geometry.coordinates);
-          }
-        }
-        return feature.id;
-      });
-
-      ctx.store.render();
-      return ids;
-    },
-    get: function (id) {
-      var feature = ctx.store.get(id);
-      if (feature) {
-        return feature.toGeoJSON();
-      }
-    },
-    getAll: function() {
-      return {
-        type: 'FeatureCollection',
-        features: ctx.store.getAll().map(feature => feature.toGeoJSON())
-      };
-    },
-    delete: function(featureIds) {
-      ctx.store.delete(featureIds, { silent: true });
-      // If we were in direct select mode and our selected feature no longer exists
-      // (because it was deleted), we need to get out of that mode.
-      if (this.getMode() === Constants.modes.DIRECT_SELECT && !ctx.store.getSelectedIds().length) {
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent: true });
+        let internalFeature = new model(ctx, feature);
+        ctx.store.add(internalFeature);
       } else {
-        ctx.store.render();
+        // If a feature of that id has already been created, and we are swapping it out ...
+        let internalFeature = ctx.store.get(feature.id);
+        internalFeature.properties = feature.properties;
+        if (!isEqual(internalFeature.getCoordinates(), feature.geometry.coordinates)) {
+          internalFeature.incomingCoords(feature.geometry.coordinates);
+        }
       }
-    },
-    deleteAll: function() {
-      ctx.store.delete(ctx.store.getAllIds(), { silent: true });
-      // If we were in direct select mode, now our selected feature no longer exists,
-      // so escape that mode.
-      if (this.getMode() === Constants.modes.DIRECT_SELECT) {
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent: true });
-      } else {
-        ctx.store.render();
-      }
-    },
-    changeMode: function(mode, modeOptions = {}) {
-      // Avoid changing modes just to re-select what's already selected
-      if (mode === Constants.modes.SIMPLE_SELECT && this.getMode() === Constants.modes.SIMPLE_SELECT) {
-        if (stringSetsAreEqual((modeOptions.featureIds || []), ctx.store.getSelectedIds())) return;
-        // And if we are changing the selection within simple_select mode, just change the selection,
-        // instead of stopping and re-starting the mode
-        return ctx.store.setSelected(modeOptions.featureIds, { silent: true });
-      }
+      return feature.id;
+    });
 
-      if (mode === Constants.modes.DIRECT_SELECT && this.getMode() === Constants.modes.DIRECT_SELECT
-        && modeOptions.featureId === ctx.store.getSelectedIds()[0]) {
-        return;
-      }
+    ctx.store.render();
+    return ids;
+  };
 
-      ctx.events.changeMode(mode, modeOptions, { silent: true });
-    },
-    getMode: function() {
-      return ctx.events.getMode();
-    },
-    trash: function() {
-      ctx.events.trash({ silent: true });
+
+  api.get = function (id) {
+    var feature = ctx.store.get(id);
+    if (feature) {
+      return feature.toGeoJSON();
     }
   };
+
+  api.getAll = function() {
+    return {
+      type: 'FeatureCollection',
+      features: ctx.store.getAll().map(feature => feature.toGeoJSON())
+    };
+  };
+
+  api.delete = function(featureIds) {
+    ctx.store.delete(featureIds, { silent: true });
+    // If we were in direct select mode and our selected feature no longer exists
+    // (because it was deleted), we need to get out of that mode.
+    if (api.getMode() === Constants.modes.DIRECT_SELECT && !ctx.store.getSelectedIds().length) {
+      ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent: true });
+    } else {
+      ctx.store.render();
+    }
+
+    return api;
+  };
+
+  api.deleteAll = function() {
+    ctx.store.delete(ctx.store.getAllIds(), { silent: true });
+    // If we were in direct select mode, now our selected feature no longer exists,
+    // so escape that mode.
+    if (api.getMode() === Constants.modes.DIRECT_SELECT) {
+      ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent: true });
+    } else {
+      ctx.store.render();
+    }
+
+    return api;
+  };
+
+  api.changeMode = function(mode, modeOptions = {}) {
+    // Avoid changing modes just to re-select what's already selected
+    if (mode === Constants.modes.SIMPLE_SELECT && api.getMode() === Constants.modes.SIMPLE_SELECT) {
+      if (stringSetsAreEqual((modeOptions.featureIds || []), ctx.store.getSelectedIds())) return api;
+      // And if we are changing the selection within simple_select mode, just change the selection,
+      // instead of stopping and re-starting the mode
+      ctx.store.setSelected(modeOptions.featureIds, { silent: true });
+      return api;
+    }
+
+    if (mode === Constants.modes.DIRECT_SELECT && api.getMode() === Constants.modes.DIRECT_SELECT
+      && modeOptions.featureId === ctx.store.getSelectedIds()[0]) {
+      return api;
+    }
+
+    ctx.events.changeMode(mode, modeOptions, { silent: true });
+    return api;
+  };
+
+  api.getMode = function() {
+    return ctx.events.getMode();
+  };
+
+  api.trash = function() {
+    ctx.events.trash({ silent: true });
+    return api;
+  };
+
+  return api;
 };

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -7,6 +7,10 @@ module.exports = function(ctx, opts) {
   var featureId = opts.featureId;
   var feature = ctx.store.get(featureId);
 
+  if (!feature) {
+    throw new Error('You must provide a featureId to enter direct_select mode');
+  }
+
   if (feature.type === 'Point') {
     throw new TypeError('direct_select mode doesn\'t handle point features');
   }

--- a/src/render.js
+++ b/src/render.js
@@ -14,8 +14,7 @@ module.exports = function render() {
 
   if (store.isDirty) {
     newColdIds = store.getAllIds();
-  }
-  else {
+  } else {
     newHotIds = store.getChangedIds().filter(id => store.get(id) !== undefined);
     newColdIds = store.sources.hot.filter(function getColdIds(geojson) {
       return geojson.properties.id && newHotIds.indexOf(geojson.properties.id) === -1 && store.get(geojson.properties.id) !== undefined;

--- a/src/setup.js
+++ b/src/setup.js
@@ -40,7 +40,7 @@ module.exports = function(ctx) {
         map.dragPan.enable();
       }
 
-      if (map.style.loaded()) { // not public
+      if (map.loaded()) {
         setup.addLayers();
         ctx.events.addEventListeners();
       } else {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -62,12 +62,12 @@ test('Draw.set', t => {
     type: 'FeatureCollection',
     features: [point, line, polygon]
   };
-  const returnValue = Draw.set(collection);
-  t.equal(returnValue.length, 3,
+  const drawInstance = Draw.set(collection);
+  t.equal(drawInstance.length, 3,
     'return value is correct length');
-  const pointId = returnValue[0];
-  const lineId = returnValue[1];
-  const polygonId = returnValue[2];
+  const pointId = drawInstance[0];
+  const lineId = drawInstance[1];
+  const polygonId = drawInstance[2];
   t.equal(Draw.get(pointId).geometry.type, 'Point',
     'point id returned');
   t.equal(Draw.get(lineId).geometry.type, 'LineString',
@@ -84,10 +84,10 @@ test('Draw.set', t => {
     type: 'FeatureCollection',
     features: [polygon]
   };
-  const nextReturnValue = Draw.set(nextCollection);
-  t.equal(nextReturnValue.length, 1,
+  const nextDrawInstance = Draw.set(nextCollection);
+  t.equal(nextDrawInstance.length, 1,
     'return value is correct length');
-  const nextPolygonId = nextReturnValue[0];
+  const nextPolygonId = nextDrawInstance[0];
   t.equal(Draw.get(nextPolygonId).geometry.type, 'Polygon',
     'polygon id returned');
   t.equal(Draw.getAll().features.length, 1,
@@ -113,11 +113,11 @@ test('Draw.set', t => {
     type: 'FeatureCollection',
     features: [newLine, overlappingPolygon]
   };
-  const overlappingReturnValue = Draw.set(overlappingCollection);
-  t.equal(overlappingReturnValue.length, 2,
+  const overlappingDrawInstance = Draw.set(overlappingCollection);
+  t.equal(overlappingDrawInstance.length, 2,
     'return value is correct length');
-  const newLineId = overlappingReturnValue[0];
-  const overlappingPolygonId = overlappingReturnValue[1];
+  const newLineId = overlappingDrawInstance[0];
+  const overlappingPolygonId = overlappingDrawInstance[1];
   t.equal(Draw.get(newLineId).geometry.type, 'LineString',
     'new line id returned');
   t.equal(Draw.get(overlappingPolygonId).geometry.type, 'Polygon',
@@ -241,8 +241,8 @@ test('Draw.getAll', t => {
 
 test('Draw.delete one feature', t => {
   var id = Draw.add(getGeoJSON('point'))[0];
-  const returnValue = Draw.delete(id);
-  t.equals(returnValue, Draw, 'returns Draw instance');
+  const drawInstance = Draw.delete(id);
+  t.equals(drawInstance, Draw, 'returns Draw instance');
   t.equals(Draw.getAll().features.length, 0, 'can remove a feature by its id');
   t.end();
 });
@@ -251,8 +251,8 @@ test('Draw.delete multiple features', t => {
   var [pointId] = Draw.add(getGeoJSON('point'));
   var [lineId] = Draw.add(getGeoJSON('line'));
   Draw.add(getGeoJSON('polygon'));
-  const returnValue = Draw.delete([pointId, lineId]);
-  t.equals(returnValue, Draw, 'returns Draw instance');
+  const drawInstance = Draw.delete([pointId, lineId]);
+  t.equals(drawInstance, Draw, 'returns Draw instance');
   t.equals(Draw.getAll().features.length, 1, 'can remove multiple features by id');
   t.equals(Draw.getAll().features[0].geometry.type, 'Polygon',
     'the right features were removed');
@@ -271,8 +271,8 @@ test('Draw.delete a feature that is direct_selected', t => {
 
 test('Draw.deleteAll', t => {
   Draw.add(getGeoJSON('point'));
-  const returnValue = Draw.deleteAll();
-  t.equals(returnValue, Draw, 'returns Draw instance');
+  const drawInstance = Draw.deleteAll();
+  t.equals(drawInstance, Draw, 'returns Draw instance');
   t.equals(Draw.getAll().features.length, 0, 'Draw.deleteAll removes all geometries');
   t.end();
 });
@@ -292,8 +292,8 @@ test('Draw.deleteAll when in direct_select mode', t => {
 });
 
 test('Draw.changeMode and Draw.getMode with no pre-existing feature', t => {
-  const returnValue = Draw.changeMode('draw_polygon');
-  t.equals(returnValue, Draw, 'changeMode returns Draw instance');
+  const drawInstance = Draw.changeMode('draw_polygon');
+  t.equals(drawInstance, Draw, 'changeMode returns Draw instance');
   t.equals(Draw.getMode(), 'draw_polygon', 'changed to draw_polygon');
   t.equals(Draw.getAll().features.length, 1, 'one feature added');
   t.equals(Draw.getAll().features[0].geometry.type, 'Polygon', 'and it is a polygon');

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,169 +1,364 @@
 /* eslint no-shadow:[0] */
 import test from 'tape';
-import mapboxgl from 'mapbox-gl-js-mock';
+import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import GLDraw from '../';
 import createMap from './utils/create_map';
 import getGeoJSON from './utils/get_geojson';
 import AfterNextRender from './utils/after_next_render';
 
-var feature = getGeoJSON('point');
+var map = createMap();
+var afterNextRender = AfterNextRender(map);
+var Draw = GLDraw();
+map.addControl(Draw);
+const addSpy = spy(Draw, 'add');
+const deleteSpy = spy(Draw, 'delete');
 
-test('API test', t => {
-
-  var map = createMap();
-  var afterNextRender = AfterNextRender(map);
-  var Draw = GLDraw();
-  map.addControl(Draw);
-
-  test('init map', t => {
-    if(map.loaded()) {
-      t.end();
-    }
-    else {
-      map.once('load', () => t.end());
-    }
-  });
-
-  t.test('Draw.getFeatureIdsAt', t => {
-    var id = Draw.add(feature)[0];
-    afterNextRender(() => {
-      // These tests require the the pixel space
-      // and lat/lng space are equal (1px = 1deg)
-      var featureIds = Draw.getFeatureIdsAt({
-        x: feature.geometry.coordinates[0],
-        y: feature.geometry.coordinates[1],
-      });
-
-      t.equals(featureIds.length, 1, 'should have selected the feature');
-      t.equals(featureIds[0], id, 'selected feature should match desired feature');
-      Draw.deleteAll();
-      t.end();
+test('Draw.getFeatureIdsAt', t => {
+  var feature = getGeoJSON('point');
+  var [id] = Draw.add(feature);
+  afterNextRender(() => {
+    // These tests require the the pixel space
+    // and lat/lng space are equal (1px = 1deg)
+    var featureIds = Draw.getFeatureIdsAt({
+      x: feature.geometry.coordinates[0],
+      y: feature.geometry.coordinates[1]
     });
-  });
 
-  t.test('Draw.deleteAll', t => {
-    Draw.add(getGeoJSON('point'));
-    Draw.deleteAll();
-    t.equals(Draw.getAll().features.length, 0, 'Draw.deleteAll removes all geometries');
-    t.end();
-  });
-
-  t.test('Draw.changeMode', t => {
-
-    Draw.changeMode('draw_'+Draw.types.POLYGON);
-    var featureCollection = Draw.getAll();
-    t.equals(featureCollection.features[0].geometry.type, 'Polygon', 'Polygon');
-
-    Draw.changeMode('draw_'+Draw.types.POINT);
-    var featureCollection = Draw.getAll();
-    t.equals(featureCollection.features[0].geometry.type, 'Point', 'Point');
-
-    Draw.changeMode('draw_'+Draw.types.LINE);
-    var featureCollection = Draw.getAll();
-    t.equals(featureCollection.features[0].geometry.type, 'LineString', 'Line');
-    Draw.deleteAll();
-
-    t.end();
-  });
-
-  t.test('Draw.add -- point', t => {
-    var id = Draw.add(getGeoJSON('point'))[0];
-    t.equals(typeof id, 'string', 'valid string id returned on add');
+    t.equals(featureIds.length, 1, 'should return the added feature');
+    t.equals(featureIds[0], id, 'selected feature should match desired feature');
     Draw.deleteAll();
     t.end();
   });
+});
 
-  t.test('Draw.add -- FeatureCollection', t => {
-    var listOfIds = Draw.add(getGeoJSON('featureCollection'));
-    t.equals(listOfIds.length, getGeoJSON('featureCollection').features.length,
-      'valid string id returned when adding a featureCollection');
+test('Draw.getSelectedIds', t => {
+  const [lineId] = Draw.add(getGeoJSON('line'));
+  const [pointId] = Draw.add(getGeoJSON('point'));
+  const [polygonId] = Draw.add(getGeoJSON('polygon'));
+  Draw.changeMode('simple_select', { featureIds: [lineId, pointId] });
+  const selected = Draw.getSelectedIds();
+  t.equal(selected.length, 2,
+    'returns correct number of ids');
+  t.notEqual(selected.indexOf(lineId), -1,
+    'result contains line');
+  t.notEqual(selected.indexOf(pointId), -1,
+    'result contains point');
+  Draw.changeMode('simple_select', { featureIds: [polygonId] });
+  const nextSelected = Draw.getSelectedIds();
+  t.equal(nextSelected.length, 1,
+    'updates length');
+  t.equal(nextSelected[0], polygonId,
+    'updates content');
+  t.end();
+});
+
+test('Draw.set', t => {
+  const point = getGeoJSON('point');
+  const line = getGeoJSON('line');
+  const polygon = getGeoJSON('polygon');
+
+  // First set it to one collection
+  const collection = {
+    type: 'FeatureCollection',
+    features: [point, line, polygon]
+  };
+  const returnValue = Draw.set(collection);
+  t.equal(returnValue.length, 3,
+    'return value is correct length');
+  const pointId = returnValue[0];
+  const lineId = returnValue[1];
+  const polygonId = returnValue[2];
+  t.equal(Draw.get(pointId).geometry.type, 'Point',
+    'point id returned');
+  t.equal(Draw.get(lineId).geometry.type, 'LineString',
+    'line id returned');
+  t.equal(Draw.get(polygonId).geometry.type, 'Polygon',
+    'polygon id returned');
+  t.equal(Draw.getAll().features.length, 3,
+    'all features loaded');
+
+  // Then set to another
+  addSpy.reset();
+  deleteSpy.reset();
+  const nextCollection = {
+    type: 'FeatureCollection',
+    features: [polygon]
+  };
+  const nextReturnValue = Draw.set(nextCollection);
+  t.equal(nextReturnValue.length, 1,
+    'return value is correct length');
+  const nextPolygonId = nextReturnValue[0];
+  t.equal(Draw.get(nextPolygonId).geometry.type, 'Polygon',
+    'polygon id returned');
+  t.equal(Draw.getAll().features.length, 1,
+    'all features replaced with new ones');
+  t.ok(addSpy.calledWith(nextCollection),
+    'Draw.add called with new collection');
+  t.equal(deleteSpy.callCount, 1,
+    'Draw.delete called');
+  t.deepEqual(deleteSpy.getCall(0).args, [[
+    pointId,
+    lineId,
+    polygonId
+  ]], 'Draw.delete called with old features');
+
+  // Then set to another that contains a feature
+  // with an already-used id
+  addSpy.reset();
+  deleteSpy.reset();
+  const newLine = getGeoJSON('line');
+  const overlappingPolygon = getGeoJSON('polygon');
+  overlappingPolygon.id = nextPolygonId;
+  const overlappingCollection = {
+    type: 'FeatureCollection',
+    features: [newLine, overlappingPolygon]
+  };
+  const overlappingReturnValue = Draw.set(overlappingCollection);
+  t.equal(overlappingReturnValue.length, 2,
+    'return value is correct length');
+  const newLineId = overlappingReturnValue[0];
+  const overlappingPolygonId = overlappingReturnValue[1];
+  t.equal(Draw.get(newLineId).geometry.type, 'LineString',
+    'new line id returned');
+  t.equal(Draw.get(overlappingPolygonId).geometry.type, 'Polygon',
+    'overlapping polygon id returned');
+  t.equal(overlappingPolygonId, nextPolygonId,
+    'overlapping polygon id did not change');
+  t.ok(addSpy.calledWith(overlappingCollection),
+    'Draw.add called with overlapping collection');
+  t.equal(deleteSpy.callCount, 0,
+    'Draw.delete not called');
+
+  t.end();
+});
+
+test('Draw.set errors', t => {
+  t.throws(() => {
+    Draw.set(getGeoJSON('point'));
+  }, 'when you pass a feature');
+  t.throws(() => {
+    Draw.set({
+      type: 'FeatureCollection'
+    });
+  }, 'when you pass a collection without features');
+  t.end();
+});
+
+test('Draw.add -- point', t => {
+  var id = Draw.add(getGeoJSON('point'))[0];
+  t.equals(typeof id, 'string', 'valid string id returned on add');
+  Draw.deleteAll();
+  t.end();
+});
+
+test('Draw.add -- FeatureCollection', t => {
+  var listOfIds = Draw.add(getGeoJSON('featureCollection'));
+  t.equals(listOfIds.length, getGeoJSON('featureCollection').features.length,
+    'valid string id returned when adding a featureCollection');
+  Draw.deleteAll();
+  t.end();
+});
+
+test('Draw.add -- MultiPolygon', t => {
+  var multiId = Draw.add(getGeoJSON('multiPolygon'))[0];
+  t.equals('string', typeof multiId, 'accepts multi features');
+  Draw.deleteAll();
+  t.end();
+});
+
+test('Draw.add -- null geometry', t => {
+  t.throws(() => {
+    Draw.add(getGeoJSON('nullGeometry'));
+  }, 'null geometry is invalid');
+  t.end();
+});
+
+test('Draw.add -- GeometryCollection', t => {
+  t.throws(() => {
+    Draw.add(getGeoJSON('geometryCollection'));
+  }, 'geometry collections are not valid in Draw');
+  t.end();
+});
+
+test('Draw.add -- Invalid geojson', t => {
+  t.throws(() => {
+    Draw.add({});
+  }, 'Invlaid GeoJSON throws an error');
+  t.end();
+});
+
+test('Draw.add -- change geometry type', t => {
+  var id = Draw.add(getGeoJSON('point'))[0];
+  var polygon = getGeoJSON('polygon');
+  polygon.id = id;
+  Draw.add(polygon);
+  t.deepEquals(polygon, Draw.get(id), 'changed geometry type');
+  Draw.deleteAll();
+  t.end();
+});
+
+test('Draw.add -- existing feature with changed properties', t => {
+  var id = Draw.add(getGeoJSON('point'));
+  var point = Draw.get(id);
+
+  afterNextRender(() => {
+    point.properties = {'testing': 123};
+    Draw.add(point);
+    point = Draw.get(id);
+    t.equals('testing', Object.keys(point.properties)[0]);
+    t.equals(123, point.properties.testing);
     Draw.deleteAll();
     t.end();
   });
+});
 
-  t.test('Draw.add -- MultiPolygon', t => {
-    var multiId = Draw.add(getGeoJSON('multiPolygon'))[0];
-    t.equals('string', typeof multiId, 'accepts multi features');
-    Draw.deleteAll();
+test('Draw.get', t => {
+  var id = Draw.add(getGeoJSON('point'));
+  var f = Draw.get(id);
+  t.deepEquals(
+    getGeoJSON('point').geometry.coordinates,
+    f.geometry.coordinates,
+    'the geometry added is the same returned by Draw.get'
+  );
+
+  t.equal(Draw.get('foo'), undefined,
+    'returned undefined when no feature found');
+
+  Draw.deleteAll();
+  t.end();
+});
+
+test('Draw.getAll', t => {
+  Draw.add(getGeoJSON('point'));
+  t.deepEquals(
+    getGeoJSON('point').geometry,
+    Draw.getAll().features[0].geometry,
+    'the geometry added is the same returned by Draw.getAll'
+  );
+  Draw.deleteAll();
+  t.end();
+});
+
+test('Draw.delete one feature', t => {
+  var id = Draw.add(getGeoJSON('point'))[0];
+  const returnValue = Draw.delete(id);
+  t.equals(returnValue, Draw, 'returns Draw instance');
+  t.equals(Draw.getAll().features.length, 0, 'can remove a feature by its id');
+  t.end();
+});
+
+test('Draw.delete multiple features', t => {
+  var [pointId] = Draw.add(getGeoJSON('point'));
+  var [lineId] = Draw.add(getGeoJSON('line'));
+  Draw.add(getGeoJSON('polygon'));
+  const returnValue = Draw.delete([pointId, lineId]);
+  t.equals(returnValue, Draw, 'returns Draw instance');
+  t.equals(Draw.getAll().features.length, 1, 'can remove multiple features by id');
+  t.equals(Draw.getAll().features[0].geometry.type, 'Polygon',
+    'the right features were removed');
+  Draw.deleteAll();
+  t.end();
+});
+
+test('Draw.delete a feature that is direct_selected', t => {
+  var [id] = Draw.add(getGeoJSON('polygon'));
+  Draw.changeMode('direct_select', { featureId: id });
+  Draw.delete([id]);
+  t.equals(Draw.getAll().features.length, 0, 'removed the feature');
+  t.equals(Draw.getMode(), 'simple_select', 'changed modes to simple_select');
+  t.end();
+});
+
+test('Draw.deleteAll', t => {
+  Draw.add(getGeoJSON('point'));
+  const returnValue = Draw.deleteAll();
+  t.equals(returnValue, Draw, 'returns Draw instance');
+  t.equals(Draw.getAll().features.length, 0, 'Draw.deleteAll removes all geometries');
+  t.end();
+});
+
+test('Draw.deleteAll when in direct_select mode', t => {
+  Draw.add(getGeoJSON('point'));
+  const id = Draw.add(getGeoJSON('line'));
+  Draw.changeMode('direct_select', { featureId: id });
+  Draw.deleteAll();
+  afterNextRender(() => {
+    t.equal(Draw.getMode(), 'simple_select',
+      'switches to simple_select mode');
+    t.equal(Draw.getAll().features.length, 0,
+      'removes selected feature along with others');
     t.end();
   });
+});
 
-  t.test('Draw.add -- null geometry', t => {
-      t.throws(() => { Draw.add(getGeoJSON('nullGeometry'))}, 'null geometry is invalid');
-      t.end();
-  });
+test('Draw.changeMode and Draw.getMode with no pre-existing feature', t => {
+  const returnValue = Draw.changeMode('draw_polygon');
+  t.equals(returnValue, Draw, 'changeMode returns Draw instance');
+  t.equals(Draw.getMode(), 'draw_polygon', 'changed to draw_polygon');
+  t.equals(Draw.getAll().features.length, 1, 'one feature added');
+  t.equals(Draw.getAll().features[0].geometry.type, 'Polygon', 'and it is a polygon');
+  t.deepEquals(Draw.getAll().features[0].geometry.coordinates, [[null]], 'and it is empty');
 
-  t.test('Draw.add -- GeometryCollection', t => {
-      t.throws(() => { Draw.add(getGeoJSON('geometryCollection'))}, 'geometry collections are not valid in Draw');
-      t.end();
-  });
+  Draw.changeMode('draw_line_string');
+  t.equals(Draw.getMode(), 'draw_line_string', 'changed to draw_line_string');
+  t.equals(Draw.getAll().features.length, 1, 'still only one feature added');
+  t.equals(Draw.getAll().features[0].geometry.type, 'LineString', 'and it is a line');
+  t.deepEquals(Draw.getAll().features[0].geometry.coordinates, [], 'and it is empty');
 
-  t.test('Draw.add -- Invalid geojson', t => {
-      t.throws(() => { Draw.add({})}, 'Invlaid GeoJSON throws an error');
-      t.end();
-  });
+  Draw.changeMode('draw_point');
+  t.equals(Draw.getMode(), 'draw_point', 'changed to draw_point');
+  t.equals(Draw.getAll().features.length, 1, 'still only one feature added');
+  t.equals(Draw.getAll().features[0].geometry.type, 'Point', 'and it is a point');
+  t.deepEquals(Draw.getAll().features[0].geometry.coordinates, [], 'and it is empty');
 
-  t.test('Draw.add -- change geometry type', t => {
-    var id = Draw.add(getGeoJSON('point'))[0];
-    var polygon = getGeoJSON('polygon');
-    polygon.id = id;
-    Draw.add(polygon);
-    t.deepEquals(polygon, Draw.get(id), 'changed geometry type');
-    Draw.deleteAll();
-    t.end();
-  });
+  Draw.changeMode('simple_select');
+  t.equals(Draw.getMode(), 'simple_select', 'changed to simple_select');
+  t.equals(Draw.getAll().features.length, 0, 'no features added');
 
-  t.test('Draw.add -- existing feature with changed properties', t => {
-    var id = Draw.add(getGeoJSON('point'));
-    var point = Draw.get(id);
+  t.throws(() => {
+    Draw.changeMode('direct_select');
+  }, 'cannot enter direct_select mode with a featureId');
 
-    setTimeout(function() {
-      point.properties = {'testing': 123};
-      Draw.add(point);
-      point = Draw.get(id);
-      t.equals('testing', Object.keys(point.properties)[0]);
-      t.equals(123, point.properties.testing);
-      Draw.deleteAll();
-      t.end();
-    }, 32);
-  });
+  t.end();
+});
 
-  t.test('Draw.get', t => {
-    var id = Draw.add(getGeoJSON('point'));
-    var f = Draw.get(id);
-    t.deepEquals(
-      getGeoJSON('point').geometry.coordinates,
-      f.geometry.coordinates,
-      'the geometry added is the same returned by Draw.get'
-    );
+test('Draw.changeMode to select and de-select pre-existing features', t => {
+  const [polygonId] = Draw.add(getGeoJSON('polygon'));
+  const [lineId] = Draw.add(getGeoJSON('line'));
+  const [pointId] = Draw.add(getGeoJSON('point'));
 
-    Draw.deleteAll();
-    t.end();
-  });
+  const returnA = Draw.changeMode('simple_select', { featureIds: [polygonId, lineId]});
+  t.equals(returnA, Draw, 'returns Draw instance');
+  t.equals(Draw.getMode(), 'simple_select', 'changed to simple_select');
+  t.deepEquals(Draw.getSelectedIds(), [polygonId, lineId],
+    'polygon and line are selected');
 
-  t.test('Draw.getAll', t => {
-    Draw.add(getGeoJSON('point'));
-    t.deepEquals(
-      getGeoJSON('point').geometry,
-      Draw.getAll().features[0].geometry,
-      'the geometry added is the same returned by Draw.getAll'
-    );
-    Draw.deleteAll();
-    t.end();
-  });
+  const returnB = Draw.changeMode('simple_select', { featureIds: [polygonId, lineId]});
+  t.equals(returnB, Draw, 'returns Draw instance');
+  t.deepEquals(Draw.getSelectedIds(), [polygonId, lineId],
+    'polygon and line are still selected');
 
-  t.test('Draw.delete', t => {
-    var id = Draw.add(getGeoJSON('point'))[0];
-    Draw.delete(id);
-    t.equals(Draw.getAll().features.length, 0, 'can remove a feature by its id');
-    t.end();
-  });
+  const returnC = Draw.changeMode('simple_select', { featureIds: [pointId] });
+  t.equals(returnC, Draw, 'returns Draw instance');
+  t.deepEquals(Draw.getSelectedIds(), [pointId],
+    'change to simple_select with different featureIds to change selection');
 
+  const returnD = Draw.changeMode('direct_select', { featureId: polygonId });
+  t.equals(returnD, Draw, 'returns Draw instance');
+  t.deepEquals(Draw.getSelectedIds(), [polygonId],
+    'change to direct_select changes selection');
 
-  t.test('done', t => {
-    Draw.deleteAll();
-    Draw.remove();
-    t.end();
-  });
+  const returnE = Draw.changeMode('direct_select', { featureId: polygonId });
+  t.equals(returnE, Draw, 'returns Draw instance');
+  t.deepEquals(Draw.getSelectedIds(), [polygonId],
+    'changing to direct_select with same selection does nothing');
 
+  Draw.deleteAll();
+  t.end();
+});
+
+test('Cleanup', t => {
+  Draw.deleteAll();
+  Draw.remove();
+  t.end();
 });


### PR DESCRIPTION
@mcwhittemore:

Almost all of the changes in `api.js` are just indent changing, because I created the `api` object before the methods so it was easy to return without worrying about `this` context.

I have one test set failing because of `map.queryRenderedFeatures()` ...