### PR TITLE
Render after changing selection

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -130,6 +130,7 @@ module.exports = function(ctx) {
       // And if we are changing the selection within simple_select mode, just change the selection,
       // instead of stopping and re-starting the mode
       ctx.store.setSelected(modeOptions.featureIds, { silent: true });
+      ctx.store.render();
       return api;
     }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -340,21 +340,25 @@ test('Draw.changeMode to select and de-select pre-existing features', t => {
 
   const returnC = Draw.changeMode('simple_select', { featureIds: [pointId] });
   t.equals(returnC, Draw, 'returns Draw instance');
-  t.deepEquals(Draw.getSelectedIds(), [pointId],
-    'change to simple_select with different featureIds to change selection');
+  afterNextRender(() => {
+    t.pass('a render occurred when selection changed');
 
-  const returnD = Draw.changeMode('direct_select', { featureId: polygonId });
-  t.equals(returnD, Draw, 'returns Draw instance');
-  t.deepEquals(Draw.getSelectedIds(), [polygonId],
-    'change to direct_select changes selection');
+    t.deepEquals(Draw.getSelectedIds(), [pointId],
+      'change to simple_select with different featureIds to change selection');
 
-  const returnE = Draw.changeMode('direct_select', { featureId: polygonId });
-  t.equals(returnE, Draw, 'returns Draw instance');
-  t.deepEquals(Draw.getSelectedIds(), [polygonId],
-    'changing to direct_select with same selection does nothing');
+    const returnD = Draw.changeMode('direct_select', { featureId: polygonId });
+    t.equals(returnD, Draw, 'returns Draw instance');
+    t.deepEquals(Draw.getSelectedIds(), [polygonId],
+      'change to direct_select changes selection');
 
-  Draw.deleteAll();
-  t.end();
+    const returnE = Draw.changeMode('direct_select', { featureId: polygonId });
+    t.equals(returnE, Draw, 'returns Draw instance');
+    t.deepEquals(Draw.getSelectedIds(), [polygonId],
+      'changing to direct_select with same selection does nothing');
+
+    Draw.deleteAll();
+    t.end();
+  });
 });
 
 test('Cleanup', t => {


### PR DESCRIPTION
I found this bug while working in Studio. We need to make sure that if the selection is changed via `Draw.changeMode()`, there is a re-rendering.

@mcwhittemore for review.