### PR TITLE
No useless render on api.add

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -78,7 +78,10 @@ module.exports = function(ctx) {
       return feature.id;
     });
 
-    ctx.store.render();
+    if (ids.length) {
+      ctx.store.render();
+    }
+
     return ids;
   };
 


### PR DESCRIPTION
This little conditional prevents `Draw.add` from calling `render` if it has nothing to add. 

I think it should do no harm to add ... and for some reason it seems to fix a bug I'm seeing in Studio. The trouble is, I don't know *why*. 

The bug is that sometimes when Studio uses `Draw.set`, a feature is not deleted, *or is only partially deleted* (i.e. you can see fragments of it on the map). As far as we can tell, this only happens when you are *editing* (not initially creating) an *empty dataset*: create a polygon, deselect it, select it, delete it — and the whole or a fragment sometimes remains.

The fragmentation, when it happens, looks like it's along tile boundaries.

The fact that this conditional *seems* to fix that apparent bug suggests that the root cause has something to do with either

- Draw's `throttle` function not working right, or
- Mapbox GL JS having trouble with Draw using `setData()` multiple times in rapid succession

Either way, it seems bananas that this only happens on empty datasets ... 

Any ideas, @mcwhittemore??