### PR TITLE
Refactor render functions, improve tests; fixes #442

### DIFF
--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -75,9 +75,13 @@ module.exports = function(ctx) {
     },
 
     render(geojson, callback) {
+      const isActiveLine = geojson.properties.id === line.id;
+      geojson.properties.active = (isActiveLine) ? 'true' : 'false';
+      if (!isActiveLine) return callback(geojson);
+
+      // Only render the line if it has at least one real coordinate
       if (geojson.geometry.coordinates[0] === undefined) return;
-      geojson.properties.active = (geojson.properties.id === line.id) ? 'true' : 'false';
-      geojson.properties.meta = (geojson.properties.active === 'true') ? 'feature' : geojson.properties.meta;
+      geojson.properties.meta = 'feature';
       callback(geojson);
     },
 

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -48,11 +48,11 @@ module.exports = function(ctx) {
       }
     },
 
-    render(geojson, push) {
-      geojson.properties.active = (geojson.properties.id === point.id) ? 'true' : 'false';
-      if (geojson.properties.active === 'false') {
-        push(geojson);
-      }
+    render(geojson, callback) {
+      const isActivePoint = geojson.properties.id === point.id;
+      geojson.properties.active = (isActivePoint) ? 'true' : 'false';
+      if (!isActivePoint) return callback(geojson);
+      // Never render the point we're drawing
     },
 
     trash() {

--- a/src/render.js
+++ b/src/render.js
@@ -34,22 +34,16 @@ module.exports = function render() {
 
   var coldChanged = lastColdCount !== store.sources.cold.length || newColdIds.length > 0;
 
-  newHotIds.concat(newColdIds).concat(newColdIds).map(function prepForViewUpdates(id) {
-    if (newHotIds.indexOf(id) > -1) {
-      return {source: 'hot', 'id': id};
-    }
-    else {
-      return {source: 'cold', 'id': id};
-    }
-  }).forEach(function calculateViewUpdate(change) {
-    let {id, source} = change;
-    let feature = store.get(id);
-    let featureInternal = feature.internal(mode);
+  newHotIds.forEach(id => renderFeature(id, 'hot'));
+  newColdIds.forEach(id => renderFeature(id, 'cold'));
 
-    store.ctx.events.currentModeRender(featureInternal, function addGeoJsonToView(geojson) {
+  function renderFeature(id, source) {
+    const feature = store.get(id);
+    const featureInternal = feature.internal(mode);
+    store.ctx.events.currentModeRender(featureInternal, (geojson) => {
       store.sources[source].push(geojson);
     });
-  });
+  }
 
   if (coldChanged) {
     store.ctx.map.getSource('mapbox-gl-draw-cold').setData({

--- a/test/draw_point.test.js
+++ b/test/draw_point.test.js
@@ -1,6 +1,5 @@
 import test from 'tape';
 import xtend from 'xtend';
-import mapboxgl from 'mapbox-gl-js-mock';
 import GLDraw from '../';
 import mouseClick from './utils/mouse_click';
 import createMap from './utils/create_map';
@@ -8,7 +7,6 @@ import makeMouseEvent from './utils/make_mouse_event';
 import CommonSelectors from '../src/lib/common_selectors';
 import drawPointMode from '../src/modes/draw_point';
 import Point from '../src/feature_types/point';
-import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import createMockDrawModeContext from './utils/create_mock_draw_mode_context';
 import createMockLifecycleContext from './utils/create_mock_lifecycle_context';
 import {escapeEvent, enterEvent} from './utils/key_events';
@@ -89,7 +87,7 @@ test('draw_point stop with no point placed', t => {
   t.end();
 });
 
-test('draw_point render, active', t => {
+test('draw_point render the active point', t => {
   const context = createMockDrawModeContext();
   const mode = drawPointMode(context);
 
@@ -105,11 +103,11 @@ test('draw_point render, active', t => {
     }
   };
   mode.render(geojson, x => memo.push(x));
-  t.equal(memo.length, 0);
+  t.equal(memo.length, 0, 'active point does not render');
   t.end();
 });
 
-test('draw_point render, inactive', t => {
+test('draw_point render an inactive feature', t => {
   const context = createMockDrawModeContext();
   const mode = drawPointMode(context);
 
@@ -120,12 +118,12 @@ test('draw_point render, inactive', t => {
       meta: 'nothing'
     },
     geometry: {
-      type: 'Point',
-      coordinates: [10, 10]
+      type: 'LineString',
+      coordinates: [[10, 10], [20, 20]]
     }
   };
   mode.render(geojson, x => memo.push(x));
-  t.equal(memo.length, 1);
+  t.equal(memo.length, 1, 'does render');
   t.deepEqual(memo[0], {
     type: 'Feature',
     properties: {
@@ -133,10 +131,10 @@ test('draw_point render, inactive', t => {
       meta: 'nothing'
     },
     geometry: {
-      type: 'Point',
-      coordinates: [10, 10]
+      type: 'LineString',
+      coordinates: [[10, 10], [20, 20]]
     }
-  });
+  }, 'unaltered except active: false');
   t.end();
 });
 

--- a/test/draw_polygon.test.js
+++ b/test/draw_polygon.test.js
@@ -7,7 +7,6 @@ import makeMouseEvent from './utils/make_mouse_event';
 import CommonSelectors from '../src/lib/common_selectors';
 import drawPolygonMode from '../src/modes/draw_polygon';
 import Polygon from '../src/feature_types/polygon';
-import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import createMockDrawModeContext from './utils/create_mock_draw_mode_context';
 import createMockLifecycleContext from './utils/create_mock_lifecycle_context';
 import {
@@ -104,7 +103,49 @@ test('draw_polygon stop with invalid polygon', t => {
   }, 10);
 });
 
-test('draw_polygon render, active, with only two vertices', t => {
+test('draw_polygon render active polygon with no coordinates', t => {
+  const context = createMockDrawModeContext();
+  const mode = drawPolygonMode(context);
+
+  const memo = [];
+  const geojson = {
+    type: 'Feature',
+    properties: {
+      id: context._test.polygon.id
+    },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [[]]
+    }
+  };
+  mode.render(geojson, x => memo.push(x));
+  t.equal(memo.length, 0, 'does not render');
+
+  t.end();
+});
+
+test('draw_polygon render active polygon with 1 coordinate (and closer)', t => {
+  const context = createMockDrawModeContext();
+  const mode = drawPolygonMode(context);
+
+  const memo = [];
+  const geojson = {
+    type: 'Feature',
+    properties: {
+      id: context._test.polygon.id
+    },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [[[10, 10], [10, 10]]]
+    }
+  };
+  mode.render(geojson, x => memo.push(x));
+  t.equal(memo.length, 0, 'does not render');
+
+  t.end();
+});
+
+test('draw_polygon render active polygon with 2 coordinates (and closer)', t => {
   const context = createMockDrawModeContext();
   const mode = drawPolygonMode(context);
 
@@ -120,7 +161,7 @@ test('draw_polygon render, active, with only two vertices', t => {
     }
   };
   mode.render(geojson, x => memo.push(x));
-  t.equal(memo.length, 1);
+  t.equal(memo.length, 1, 'does render');
   t.deepEqual(memo[0], {
     type: 'Feature',
     properties: {
@@ -132,11 +173,11 @@ test('draw_polygon render, active, with only two vertices', t => {
       type: 'LineString',
       coordinates: [[0, 0], [0, 10]]
     }
-  }, 'a line string is sent to the callback');
+  }, 'renders as a LineString with meta: feature, active: true');
   t.end();
 });
 
-test('draw_polygon render, active', t => {
+test('draw_polygon render active polygon with 3 coordinates (and closer)', t => {
   const context = createMockDrawModeContext();
   const mode = drawPolygonMode(context);
 
@@ -152,7 +193,7 @@ test('draw_polygon render, active', t => {
     }
   };
   mode.render(geojson, x => memo.push(x));
-  t.equal(memo.length, 1);
+  t.equal(memo.length, 1, 'does render');
   t.deepEqual(memo[0], {
     type: 'Feature',
     properties: {
@@ -164,11 +205,11 @@ test('draw_polygon render, active', t => {
       type: 'Polygon',
       coordinates: [[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]]
     }
-  }, 'the polygon is sent to the callback');
+  }, 'renders as a polygon with meta: feature, active: true');
   t.end();
 });
 
-test('draw_polygon render, inactive', t => {
+test('draw_polygon render inactive feature', t => {
   const context = createMockDrawModeContext();
   const mode = drawPolygonMode(context);
 
@@ -179,12 +220,12 @@ test('draw_polygon render, inactive', t => {
       meta: 'meh'
     },
     geometry: {
-      type: 'Polygon',
-      coordinates: [[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]]
+      type: 'LineString',
+      coordinates: [[0, 0], [0, 10]]
     }
   };
   mode.render(geojson, x => memo.push(x));
-  t.equal(memo.length, 1);
+  t.equal(memo.length, 1, 'does render');
   t.deepEqual(memo[0], {
     type: 'Feature',
     properties: {
@@ -192,32 +233,12 @@ test('draw_polygon render, inactive', t => {
       meta: 'meh'
     },
     geometry: {
-      type: 'Polygon',
-      coordinates: [[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]]
+      type: 'LineString',
+      coordinates: [[0, 0], [0, 10]]
     }
-  }, 'the polygon is sent to the callback');
+  }, 'unaltered except active: false');
   t.end();
 });
-
-test('draw_polygon render, no coordinates', t => {
-  const context = createMockDrawModeContext();
-  const mode = drawPolygonMode(context);
-
-  const memo = [];
-  const geojson = {
-    type: 'Feature',
-    properties: {},
-    geometry: {
-      type: 'Polygon',
-      coordinates: [[]]
-    }
-  };
-  mode.render(geojson, x => memo.push(x));
-  t.equal(memo.length, 0);
-
-  t.end();
-});
-
 
 test('draw_polygon interaction', t => {
   const container = document.createElement('div');


### PR DESCRIPTION
Ref #442.

This was a good bug to uncover, because it helped me understand the rendering better.

I realized that the `draw_*` mode's render function is being used to render *every feature on the map*, not just the feature that's being drawn. So the logic in there that might *not* render some `geojson` should *only apply to the active feature, the one being drawn*.

I refactored the mode render functions to clarify this and return early for inactive features, and improved the tests to address the situation and prevent a regression of bugs like #442 (where the render function ended up not rendering an inactive feature).

Since I was looking closely at the `render` function to debug this, I also found a way to simplify that and included it in the PR.

@mcwhittemore for review. 