### PR TITLE
Prevent box-selecting outside canvas; fixes #419

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -20,7 +20,23 @@ module.exports = function(ctx) {
 
   var events = {};
   var currentModeName = Constants.modes.SIMPLE_SELECT;
-  var currentMode = ModeHandler(modes.simple_select(ctx), ctx);
+  var currentMode;
+
+  function initialize() {
+    // Add event listeners
+    ctx.map.on('mousemove', events.mousemove);
+
+    ctx.map.on('mousedown', events.mousedown);
+    ctx.map.on('mouseup', events.mouseup);
+
+    if (ctx.options.keybindings) {
+      ctx.container.addEventListener('keydown', events.keydown);
+      ctx.container.addEventListener('keyup', events.keyup);
+    }
+
+    // Start us in simple_select mode
+    currentMode = ModeHandler(modes.simple_select(ctx), ctx);
+  }
 
   events.drag = function(event) {
     if (isClick(mouseDownInfo, {
@@ -124,6 +140,7 @@ module.exports = function(ctx) {
   }
 
   var api = {
+    initialize,
     changeMode,
     currentModeName: function() {
       return currentModeName;
@@ -134,17 +151,6 @@ module.exports = function(ctx) {
     fire: function(name, event) {
       if (events[name]) {
         events[name](event);
-      }
-    },
-    addEventListeners: function() {
-      ctx.map.on('mousemove', events.mousemove);
-
-      ctx.map.on('mousedown', events.mousedown);
-      ctx.map.on('mouseup', events.mouseup);
-
-      if (ctx.options.keybindings) {
-        ctx.container.addEventListener('keydown', events.keydown);
-        ctx.container.addEventListener('keyup', events.keyup);
       }
     },
     removeEventListeners: function() {

--- a/src/setup.js
+++ b/src/setup.js
@@ -42,11 +42,11 @@ module.exports = function(ctx) {
 
       if (map.loaded()) {
         setup.addLayers();
-        ctx.events.addEventListeners();
+        ctx.events.initialize();
       } else {
         map.on('load', () => {
           setup.addLayers();
-          ctx.events.addEventListeners();
+          ctx.events.initialize();
         });
       }
     },


### PR DESCRIPTION
Ref #419.

Adding the `mouseout` listener is a stopgap measure until mapbox-gl-js has a release including mapbox/mapbox-gl-js#2777. Once that's in, we can use the Map's `mouseout` event.

The reason I made `events.initialize` was so that the mode handler is only created after the map is available.

@mcwhittemore, what do you think of this solution? If you agree with it, I'll modify the tests so they pass. If you have another idea, let me know.