### PR TITLE
Batch render calls invoked by Draw.set

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "hat": "0.0.3",
     "lodash.isequal": "^4.2.0",
     "point-geometry": "0.0.0",
-    "sinon": "^1.17.4",
     "turf-area": "^1.1.1",
     "xtend": "^4.0.1"
   }

--- a/src/api.js
+++ b/src/api.js
@@ -32,6 +32,7 @@ module.exports = function(ctx) {
     if (featureCollection.type === undefined || featureCollection.type !== 'FeatureCollection' || !Array.isArray(featureCollection.features)) {
       throw new Error('Invalid FeatureCollection');
     }
+    var renderBatch = ctx.store.createRenderBatch();
     var toDelete = ctx.store.getAllIds().slice();
     var newIds = api.add(featureCollection);
     var newIdsLookup = new StringSet(newIds);
@@ -41,6 +42,7 @@ module.exports = function(ctx) {
       api.delete(toDelete);
     }
 
+    renderBatch();
     return newIds;
   };
 

--- a/src/render.js
+++ b/src/render.js
@@ -21,10 +21,6 @@ module.exports = function render() {
     }).map(geojson => geojson.properties.id);
   }
 
-  // if (newHotIds.length + newColdIds.length === 0 && this.isDirty === false) {
-  //   return; // there is nothing to change...
-  // }
-
   store.sources.hot = [];
   let lastColdCount = store.sources.cold.length;
   store.sources.cold = store.isDirty ? [] : store.sources.cold.filter(function saveColdFeatures(geojson) {

--- a/src/store.js
+++ b/src/store.js
@@ -19,6 +19,26 @@ var Store = module.exports = function(ctx) {
   this.isDirty = false;
 };
 
+
+/**
+ * Delays all rendering until the returned function is invoked
+ * @return {Function} renderBatch
+ */
+Store.prototype.createRenderBatch = function() {
+  let holdRender = this.render;
+  let numRenders = 0;
+  this.render = function() {
+    numRenders++;
+  };
+
+  return () => {
+    this.render = holdRender;
+    if (numRenders > 0) {
+      this.render();
+    }
+  };
+};
+
 /**
  * Sets the store's state to dirty.
  * @return {Store} this

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -34,6 +34,7 @@ test('Store constructor and public API', t => {
 
   // prototype members
   t.equal(typeof Store.prototype.setDirty, 'function', 'exposes store.setDirty');
+  t.equal(typeof Store.prototype.createRenderBatch, 'function', 'exposes store.createRenderBatch');
   t.equal(typeof Store.prototype.featureChanged, 'function', 'exposes store.featureChanged');
   t.equal(typeof Store.prototype.getChangedIds, 'function', 'exposes store.getChangedIds');
   t.equal(typeof Store.prototype.clearChangedIds, 'function', 'exposes store.clearChangedIds');
@@ -50,7 +51,7 @@ test('Store constructor and public API', t => {
   t.equal(typeof Store.prototype.delete, 'function', 'exposes store.delete');
   t.equal(typeof Store.prototype.setSelected, 'function', 'exposes store.setSelected');
 
-  t.equal(getPublicMemberKeys(Store.prototype).length, 16, 'no untested prototype members');
+  t.equal(getPublicMemberKeys(Store.prototype).length, 17, 'no untested prototype members');
 
   t.end();
 });
@@ -60,6 +61,29 @@ test('Store#setDirty', t => {
   t.equal(store.isDirty, false);
   store.setDirty();
   t.equal(store.isDirty, true);
+  t.end();
+});
+
+test('Store#createRenderBatch', t => {
+  const store = createStore();
+  var numRenders = 0;
+  store.render = function() {
+    numRenders++;
+  }
+  store.render();
+  t.equal(numRenders, 1, 'render incrementes number of renders');
+  var renderBatch = store.createRenderBatch();
+  store.render();
+  store.render();
+  store.render();
+  t.equal(numRenders, 1, 'when batching render doesn\'t get incremented');
+  renderBatch();
+  t.equal(numRenders, 2, 'when releasing batch, render only happens once');
+
+  var renderBatch = store.createRenderBatch();
+  renderBatch();
+  t.equal(numRenders, 2, 'when releasing batch, render doesn\'t happen if render wasn\'t called');
+
   t.end();
 });
 


### PR DESCRIPTION
`Draw.set()` invokes render twice. Once for `Draw.add()` and once for `Draw.delete()`. Since we use `throttle` to limit the number of times we processes all of the renders this means that part of the job is sent to gl-js, then 16ms happens, and than another part of the job is sent. This can lead to some weird rendering results (due to gl-js not ensuring setData calls are rendered in the right order?). This PR solves this problem by batching the two renders into one.

This could also be solved by moving from throttle to debounce, but debounced rendering feels laggy.

Replaces #441

@davidtheclark for the review