### PR TITLE
Add mouseout and use it to cancel box select; fixes #419

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -14,10 +14,7 @@ var modes = {
 
 module.exports = function(ctx) {
 
-  var mouseDownInfo = {
-    isDown: false
-  };
-
+  var mouseDownInfo = {};
   var events = {};
   var currentModeName = Constants.modes.SIMPLE_SELECT;
   var currentMode = ModeHandler(modes.simple_select(ctx), ctx);
@@ -36,7 +33,7 @@ module.exports = function(ctx) {
   };
 
   events.mousemove = function(event) {
-    if (mouseDownInfo.isDown) {
+    if (event.originalEvent.which === 1) {
       return events.drag(event);
     }
     var target = getFeaturesAndSetCursor(event, ctx);
@@ -46,7 +43,6 @@ module.exports = function(ctx) {
 
   events.mousedown = function(event) {
     mouseDownInfo = {
-      isDown: true,
       time: new Date().getTime(),
       point: event.point
     };
@@ -56,7 +52,6 @@ module.exports = function(ctx) {
   };
 
   events.mouseup = function(event) {
-    mouseDownInfo.isDown = false;
     var target = getFeaturesAndSetCursor(event, ctx);
     event.featureTarget = target;
 

--- a/src/lib/move_feature.js
+++ b/src/lib/move_feature.js
@@ -1,0 +1,25 @@
+const Constants = require('../constants');
+
+module.exports = function(feature, lngDelta, latDelta) {
+  const featureCoordinates = feature.getCoordinates();
+
+  const moveCoordinate = (coord) => [coord[0] + lngDelta, coord[1] + latDelta];
+  const moveRing = (ring) => ring.map(coord => moveCoordinate(coord));
+  const moveMultiPolygon = (multi) => multi.map(ring => moveRing(ring));
+
+  if (feature.type === Constants.geojsonTypes.POINT) {
+    return feature.incomingCoords(moveCoordinate(featureCoordinates));
+  }
+
+  if (feature.type === Constants.geojsonTypes.LINE_STRING || feature.type === Constants.geojsonTypes.MULTI_POINT) {
+    return feature.incomingCoords(featureCoordinates.map(moveCoordinate));
+  }
+
+  if (feature.type === Constants.geojsonTypes.POLYGON || feature.type === Constants.geojsonTypes.MULTI_LINE_STRING) {
+    return feature.incomingCoords(featureCoordinates.map(moveRing));
+  }
+
+  if (feature.type === Constants.geojsonTypes.MULTI_POLYGON) {
+    return feature.incomingCoords(featureCoordinates.map(moveMultiPolygon));
+  }
+};

--- a/test/direct_select.test.js
+++ b/test/direct_select.test.js
@@ -51,7 +51,7 @@ test('direct_select', t => {
       click(map, makeMouseEvent(clickAt[0], clickAt[1]));
       afterNextRender(() => {
         map.fire('mousedown', makeMouseEvent(clickAt[0] + 15, clickAt[1] + 15));
-        map.fire('mousemove', makeMouseEvent(clickAt[0] + 30, clickAt[1] + 30));
+        map.fire('mousemove', makeMouseEvent(clickAt[0] + 30, clickAt[1] + 30, { which: 1 }));
         map.fire('mouseup', makeMouseEvent(clickAt[0] + 30, clickAt[1] + 30));
         var afterMove = Draw.get(ids[0]);
         t.deepEquals(getGeoJSON('polygon').geometry, afterMove.geometry, 'should be the same after the drag');

--- a/test/interaction_events.test.js
+++ b/test/interaction_events.test.js
@@ -136,7 +136,7 @@ function runTests() {
     // Now in `simple_select` mode ...
     map.fire('mousedown', makeMouseEvent(25, 25));
     repeat(10, i => {
-      map.fire('mousemove', makeMouseEvent(25 + i, 25 - i));
+      map.fire('mousemove', makeMouseEvent(25 + i, 25 - i, { which: 1 }));
     });
     map.fire('mouseup', makeMouseEvent(35, 10));
     afterNextRender(() => {
@@ -268,7 +268,7 @@ function runTests() {
     map.fire('mousedown', makeMouseEvent(20, 20));
     // Drag it a little bit
     repeat(10, i => {
-      map.fire('mousemove', makeMouseEvent(20 + i, 20 - i));
+      map.fire('mousemove', makeMouseEvent(20 + i, 20 - i, { which: 1 }));
     });
     // Release the mouse
     map.fire('mouseup', makeMouseEvent(30, 10));
@@ -317,7 +317,7 @@ function runTests() {
     map.fire('mousedown', makeMouseEvent(40, 20));
     // Drag it a little bit
     repeat(20, i => {
-      map.fire('mousemove', makeMouseEvent(40 + (5 * i), 20 + (5 * i)));
+      map.fire('mousemove', makeMouseEvent(40 + (5 * i), 20 + (5 * i), { which: 1 }));
     });
     // Release the mouse
     map.fire('mouseup', makeMouseEvent(140, 120));
@@ -473,9 +473,9 @@ function runTests() {
   test('box-select the line and the polygon', t => {
     // Now in `simple_select` mode ...
     // Mouse down with the shift key
-    map.fire('mousedown', makeMouseEvent(200, 200, true));
+    map.fire('mousedown', makeMouseEvent(200, 200, { shiftKey: true }));
     repeat(20, i => {
-      map.fire('mousemove', makeMouseEvent(200 - (10 * i), 200 - (10 * i)));
+      map.fire('mousemove', makeMouseEvent(200 - (10 * i), 200 - (10 * i), { which: 1 }));
     });
     map.fire('mouseup', makeMouseEvent(0, 0));
 
@@ -514,7 +514,7 @@ function runTests() {
     map.fire('mousedown', makeMouseEvent(50, 50));
     // Drag it a little bit
     repeat(20, i => {
-      map.fire('mousemove', makeMouseEvent(50 + i, 50 - i));
+      map.fire('mousemove', makeMouseEvent(50 + i, 50 - i, { which: 1 }));
     });
     // Release the mouse
     map.fire('mouseup', makeMouseEvent(70, 30));
@@ -576,7 +576,7 @@ function runTests() {
 
   test('add another vertex to the selection', t => {
     // Now in `simple_select` mode ...
-    click(map, makeMouseEvent(20, 80, true));
+    click(map, makeMouseEvent(20, 80, { shiftKey: true }));
     afterNextRender(() => {
       t.deepEqual(flushDrawEvents(), [], 'no unexpected draw events');
       t.end();
@@ -598,7 +598,7 @@ function runTests() {
     map.fire('mousedown', makeMouseEvent(20, 80));
     // Drag it a little bit
     repeat(20, i => {
-      map.fire('mousemove', makeMouseEvent(20 - i, 80));
+      map.fire('mousemove', makeMouseEvent(20 - i, 80, { which: 1 }));
     });
     // Release the mouse
     map.fire('mouseup', makeMouseEvent(0, 80));
@@ -652,7 +652,7 @@ function runTests() {
   test('select then delete two vertices with Draw.trash()', t => {
     // Now in `direct_select` mode ...
     click(map, makeMouseEvent(0, -20));
-    click(map, makeMouseEvent(120, -20, true));
+    click(map, makeMouseEvent(120, -20, { shiftKey: true }));
     Draw.trash();
     afterNextRender(() => {
       firedWith(t, 'draw.update', {
@@ -689,7 +689,7 @@ function runTests() {
   test('add the line to the selection', t => {
     // Now in `simple_select` mode ...
     // shift-click to add to selection
-    click(map, makeMouseEvent(100, 40, true));
+    click(map, makeMouseEvent(100, 40, { shiftKey: true }));
     afterNextRender(() => {
       firedWith(t, 'draw.selectionchange', {
         features: [polygon0_120_120_0GeoJson, line40_100_160GeoJson]
@@ -906,8 +906,8 @@ function runTests() {
   test('box selection includes no features', t => {
     Draw.deleteAll();
     Draw.changeMode('simple_select');
-    click(map, makeMouseEvent(0, 0, true));
-    click(map, makeMouseEvent(100, 100, true));
+    click(map, makeMouseEvent(0, 0, { shiftKey: true }));
+    click(map, makeMouseEvent(100, 100, { shiftKey: true }));
     afterNextRender(() => {
       t.deepEqual(flushDrawEvents(), [], 'no unexpected draw events');
       t.end();

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -56,10 +56,10 @@ test('static', t => {
 
     afterNextRender(() => {
       map.dragPan.disable.reset();
-      map.fire('mousedown', makeMouseEvent(0, 0, true));
+      map.fire('mousedown', makeMouseEvent(0, 0, { shiftKey: true }));
       t.equal(map.dragPan.disable.callCount, 0, 'dragPan is still enabled');
-      map.fire('mousemove', makeMouseEvent(15, 15, true));
-      map.fire('mouseup', makeMouseEvent(15, 15, true));
+      map.fire('mousemove', makeMouseEvent(15, 15, { shiftKey: true }));
+      map.fire('mouseup', makeMouseEvent(15, 15, { shiftKey: true }));
 
       var args = getFireArgs().filter(arg => arg[0] === 'draw.selectionchange');
       t.equal(args.length, 0, 'should have zero selectionchange events');

--- a/test/utils/make_mouse_event.js
+++ b/test/utils/make_mouse_event.js
@@ -1,15 +1,16 @@
-module.exports = function(lng, lat, shiftKey = false) {
+const xtend = require('xtend');
+
+module.exports = function(lng, lat, eventProperties = {}) {
   var e = {
-    originalEvent: {
-      shiftKey: shiftKey,
+    originalEvent: xtend({
       stopPropagation: function() {},
       button: 0,
       clientX: lng,
       clientY: lat
-    },
+    }, eventProperties),
     point: {x: lng, y:lat},
     lngLat: {lng: lng, lat: lat}
   };
 
   return e;
-}
+};


### PR DESCRIPTION
Re-take on PR #444 to close bug #419.

This time I used `events.js` to add the DOM listener, and added some appropriate tests.

@mcwhittemore, ready for review.