### PR TITLE
Expose Draw.modes; closes #267

### DIFF
--- a/API.md
+++ b/API.md
@@ -29,6 +29,52 @@ displayControlsDefault | boolean | Sets default value for the control keys in th
 controls | Object | Lets you hide or show individual controls. See `displayControlsDefault` for default. Available options are: point, line, polygon and trash.
 styles | Array | An array of style objects. By default draw provides a style for you. To override this see [Styling Draw](#styling-draw) further down.
 
+## Modes
+
+The modes names are available as an enum at `Draw.modes`.
+
+### `simple_select`
+
+`Draw.modes.SIMPLE_SELECT === 'simple_select'`
+
+Lets you select, delete and drag features.
+
+In this mode, features can have their active state changed by the user. To control what is active, react to changes as described in the events section below.
+
+### `direct_select`
+
+`Draw.modes.DIRECT_SELECT === 'direct_select'`
+
+Lets you select, delete and drag vertices.
+
+`direct_select` mode doesn't handle point features.
+
+### `draw_line_string`
+
+`Draw.modes.DRAW_LINE_STRING === 'draw_line_string'`
+
+Lets you draw a LineString feature.
+
+### `draw_polygon`
+
+`Draw.modes.DRAW_POLYGON === 'draw_polygon'`
+
+Lets you draw a Polygon feature.
+
+### `draw_point`
+
+`Draw.modes.DRAW_POINT === 'draw_point'`
+
+Lets you draw a Point feature.
+
+### `static`
+
+`Draw.modes.STATIC === 'static'`
+
+Disables editing for all drawn features. It does not take an options argument.
+
+Note that this mode can only be entered or exited via `.changeMode`
+
 ## API Methods
 
 `mapboxgl.Draw()` returns an instance of `Draw` which has the following API for working with your data:
@@ -203,15 +249,7 @@ Returns Draw's current mode. For more about the modes, see below.
 
 ### `.changeMode(String: mode, ?Object: options) -> Draw`
 
-`changeMode` triggers the mode switching process inside Draw. `mode` must be one of the below strings. Each mode takes its own options. They are described in detail below.
-
-#### Mode: `simple_select`
-
-Lets you select, delete and drag features.
-
-In this mode, features can have their active state changed by the user. To control what is active, react to changes as described in the events section below.
-
-This mode has the following options:
+`changeMode` triggers the mode switching process inside Draw. `mode` must be one of the below strings. `simple_select` and `direct_select` modes accept an `options` object.
 
 ```js
 // `simple_select` options
@@ -221,14 +259,6 @@ This mode has the following options:
 }
 ```
 
-#### Mode: `direct_select`
-
-Lets you select, delete and drag vertices.
-
-`direct_select` mode doesn't handle point features.
-
-This mode has the following options:
-
 ```js
 // `direct_select` options
 {
@@ -236,20 +266,6 @@ This mode has the following options:
   featureId: string
 }
 ```
-
-#### Drawing modes:
-
-The three drawing modes work identically. They do not take an options argument.
-
-- `draw_line_string`: Draws a LineString feature.
-- `draw_polygon`: Draws a Polygon feature.
-- `draw_point`: Draws a Point feature.
-
-#### Mode: `static`
-
-Disables editing for all drawn features. It does not take an options argument.
-
-Note that this mode can only be entered or exited via `.changeMode`
 
 ## Events
 

--- a/src/api.js
+++ b/src/api.js
@@ -17,7 +17,9 @@ var featureTypes = {
 };
 
 module.exports = function(ctx) {
-  const api = {};
+  const api = {
+    modes: Constants.modes
+  };
 
   api.getFeatureIdsAt = function(point) {
     var features = featuresAt({ point }, null, ctx);

--- a/src/constants.js
+++ b/src/constants.js
@@ -40,7 +40,7 @@ module.exports = {
     MULTI_POLYGON: 'MultiPolygon'
   },
   modes: {
-    DRAW_LINE: 'draw_line_string',
+    DRAW_LINE_STRING: 'draw_line_string',
     DRAW_POLYGON: 'draw_polygon',
     DRAW_POINT: 'draw_point',
     SIMPLE_SELECT: 'simple_select',

--- a/src/events.js
+++ b/src/events.js
@@ -7,7 +7,7 @@ var modes = {
   [Constants.modes.SIMPLE_SELECT]: require('./modes/simple_select'),
   [Constants.modes.DIRECT_SELECT]: require('./modes/direct_select'),
   [Constants.modes.DRAW_POINT]: require('./modes/draw_point'),
-  [Constants.modes.DRAW_LINE]: require('./modes/draw_line_string'),
+  [Constants.modes.DRAW_LINE_STRING]: require('./modes/draw_line_string'),
   [Constants.modes.DRAW_POLYGON]: require('./modes/draw_polygon'),
   [Constants.modes.STATIC]: require('./modes/static')
 };
@@ -87,7 +87,7 @@ module.exports = function(ctx) {
       changeMode(Constants.modes.DRAW_POINT);
     }
     else if (event.keyCode === 50 && ctx.options.controls.line_string) {
-      changeMode(Constants.modes.DRAW_LINE);
+      changeMode(Constants.modes.DRAW_LINE_STRING);
     }
     else if (event.keyCode === 51 && ctx.options.controls.polygon) {
       changeMode(Constants.modes.DRAW_POLYGON);

--- a/src/ui.js
+++ b/src/ui.js
@@ -116,7 +116,7 @@ module.exports = function(ctx) {
         container: controlGroup,
         className: Constants.classes.CONTROL_BUTTON_LINE,
         title: `LineString tool ${ctx.options.keybindings && '(l)'}`,
-        onActivate: () => ctx.events.changeMode(Constants.modes.DRAW_LINE)
+        onActivate: () => ctx.events.changeMode(Constants.modes.DRAW_LINE_STRING)
       });
     }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,10 +1,12 @@
 /* eslint no-shadow:[0] */
 import test from 'tape';
 import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
+import Constants from '../src/constants';
 import GLDraw from '../';
 import createMap from './utils/create_map';
 import getGeoJSON from './utils/get_geojson';
 import AfterNextRender from './utils/after_next_render';
+import getPublicMemberKeys from './utils/get_public_member_keys';
 
 var map = createMap();
 var afterNextRender = AfterNextRender(map);
@@ -359,6 +361,17 @@ test('Draw.changeMode to select and de-select pre-existing features', t => {
     Draw.deleteAll();
     t.end();
   });
+});
+
+test('Draw.modes', t => {
+  t.equal(Draw.modes.SIMPLE_SELECT, Constants.modes.SIMPLE_SELECT, 'simple_select');
+  t.equal(Draw.modes.DIRECT_SELECT, Constants.modes.DIRECT_SELECT, 'direct_select');
+  t.equal(Draw.modes.DRAW_POINT, Constants.modes.DRAW_POINT, 'draw_point');
+  t.equal(Draw.modes.DRAW_LINE_STRING, Constants.modes.DRAW_LINE_STRING, 'draw_line_string');
+  t.equal(Draw.modes.DRAW_POLYGON, Constants.modes.DRAW_POLYGON, 'draw_polygon');
+  t.equal(Draw.modes.STATIC, Constants.modes.STATIC, 'static');
+  t.equal(getPublicMemberKeys(Draw.modes).length, 6, 'no unexpected modes');
+  t.end();
 });
 
 test('Cleanup', t => {


### PR DESCRIPTION
Ref #267.

In the process of doing this I thought it would be a good idea to change `DRAW_LINE` to `DRAW_LINE_STRING`, for consistency with geojson types.

@mcwhittemore for review.