### PR TITLE
[WIP] Simplify mode interface

### DIFF
--- a/src/lib/common_selectors.js
+++ b/src/lib/common_selectors.js
@@ -40,6 +40,12 @@ module.exports = {
     if (!featureTarget.properties) return false;
     return featureTarget.properties.meta === Constants.meta.VERTEX;
   },
+  isMidpoint: function(e) {
+    var featureTarget = e.featureTarget;
+    if (!featureTarget) return false;
+    if (!featureTarget.properties) return false;
+    return featureTarget.properties.meta === Constants.meta.MIDPOINT;
+  },
   isShiftDown: function(e) {
     if (!e.originalEvent) return false;
     return e.originalEvent.shiftKey === true;

--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -11,14 +11,11 @@ var ModeHandler = function(mode, DrawContext) {
   };
 
   var ctx = {
-    on: function(event, selector, fn) {
+    on: function(event, fn) {
       if (handlers[event] === undefined) {
         throw new Error(`Invalid event type: ${event}`);
       }
-      handlers[event].push({
-        selector: selector,
-        fn: fn
-      });
+      handlers[event].push(fn);
     },
     render: function(id) {
       DrawContext.store.featureChanged(id);
@@ -26,20 +23,13 @@ var ModeHandler = function(mode, DrawContext) {
   };
 
   var delegate = function (eventName, event) {
-    var handles = handlers[eventName];
-    var iHandle = handles.length;
-    while (iHandle--) {
-      var handle = handles[iHandle];
-      if (handle.selector(event)) {
-        handle.fn.call(ctx, event);
-        DrawContext.store.render();
-        DrawContext.ui.updateMapClasses();
+    handlers[eventName].forEach(handle => {
+      handle.call(ctx, event);
+    });
 
-        // ensure an event is only handled once
-        // we do this to let modes have multiple overlapping selectors
-        // and relay on order of oppertations to filter
-        break;
-      }
+    if (handlers[eventName].length > 0) {
+      DrawContext.store.render();
+      DrawContext.ui.updateMapClasses();
     }
   };
 

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -26,13 +26,17 @@ module.exports = function(ctx) {
       doubleClickZoom.disable(ctx);
       ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
       ctx.ui.setActiveButton(Constants.types.LINE);
-      this.on('mousemove', CommonSelectors.true, (e) => {
+
+      this.on('mousemove', e => {
         line.updateCoordinate(currentVertexPosition, e.lngLat.lng, e.lngLat.lat);
         if (CommonSelectors.isVertex(e)) {
           ctx.ui.queueMapClasses({ mouse: Constants.cursors.POINTER });
         }
       });
-      this.on('click', CommonSelectors.true, (e) => {
+
+      this.on('click', e => {
+        if (CommonSelectors.isVertex(e)) return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [line.id] });
+
         if(currentVertexPosition > 0 && isEventAtCoordinates(e, line.coordinates[currentVertexPosition - 1])) {
           return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [line.id] });
         }
@@ -40,15 +44,16 @@ module.exports = function(ctx) {
         line.updateCoordinate(currentVertexPosition, e.lngLat.lng, e.lngLat.lat);
         currentVertexPosition++;
       });
-      this.on('click', CommonSelectors.isVertex, () => {
-        return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [line.id] });
-      });
-      this.on('keyup', CommonSelectors.isEscapeKey, () => {
-        ctx.store.delete([line.id], { silent: true });
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
-      });
-      this.on('keyup', CommonSelectors.isEnterKey, () => {
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [line.id] });
+
+      this.on('keyup', e => {
+        if(CommonSelectors.isEscapeKey(e)) {
+          ctx.store.delete([line.id], { silent: true });
+          return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
+        }
+
+        if (CommonSelectors.isEnterKey(e)) {
+          return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [line.id] });
+        }
       });
     },
 

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -37,8 +37,11 @@ module.exports = function(ctx) {
       ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
       ctx.ui.setActiveButton(Constants.types.POINT);
       this.on('click', CommonSelectors.true, handleClick);
-      this.on('keyup', CommonSelectors.isEscapeKey, stopDrawingAndRemove);
-      this.on('keyup', CommonSelectors.isEnterKey, stopDrawingAndRemove);
+      this.on('keyup', (e) => {
+        if (CommonSelectors.isEscapeKey(e) || CommonSelectors.isEnterKey(e)) {
+          return stopDrawingAndRemove(e);
+        }
+      });
     },
 
     stop() {

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -27,13 +27,16 @@ module.exports = function(ctx) {
       doubleClickZoom.disable(ctx);
       ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
       ctx.ui.setActiveButton(Constants.types.POLYGON);
-      this.on('mousemove', CommonSelectors.true, e => {
+      this.on('mousemove', e => {
         polygon.updateCoordinate(`0.${currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
         if (CommonSelectors.isVertex(e)) {
           ctx.ui.queueMapClasses({ mouse: Constants.cursors.POINTER });
         }
       });
-      this.on('click', CommonSelectors.true, (e) => {
+
+      this.on('click', e => {
+        if(CommonSelectors.isVertex(e)) return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [polygon.id] });
+
         if (currentVertexPosition > 0 && isEventAtCoordinates(e, polygon.coordinates[0][currentVertexPosition - 1])) {
           return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [polygon.id] });
         }
@@ -41,15 +44,16 @@ module.exports = function(ctx) {
         polygon.updateCoordinate(`0.${currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
         currentVertexPosition++;
       });
-      this.on('click', CommonSelectors.isVertex, () => {
-        return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [polygon.id] });
-      });
-      this.on('keyup', CommonSelectors.isEscapeKey, () => {
-        ctx.store.delete([polygon.id], { silent: true });
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
-      });
-      this.on('keyup', CommonSelectors.isEnterKey, () => {
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [polygon.id] });
+
+      this.on('keyup', e => {
+        if (CommonSelectors.isEscapeKey(e)) {
+          ctx.store.delete([polygon.id], { silent: true });
+          return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
+        }
+
+        if (CommonSelectors.isEnterKey(e)) {
+          return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [polygon.id] });
+        }
       });
     },
 


### PR DESCRIPTION
@davidtheclark I took a quick stab at dropping selectors per #459, but I don't really like what it does to the code.

I might be ok with this if the exported object just exposed `onClick` rather than setting up click handlers in the exposed `start` function.

What do you think?