### PR TITLE
Modes as Classes

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -3,13 +3,21 @@ var getFeaturesAndSetCursor = require('./lib/get_features_and_set_cursor');
 var isClick = require('./lib/is_click');
 var Constants = require('./constants');
 
+import SimpleSelectMode from './modes/simple_select';
+import DirectSelectMode from './modes/direct_select';
+import DrawPointMode from './modes/draw_point';
+import DrawLineStringMode from './modes/draw_line_string';
+import DrawPolygonMode from './modes/draw_polygon';
+import StaticMode from './modes/static';
+
+
 var modes = {
-  [Constants.modes.SIMPLE_SELECT]: require('./modes/simple_select'),
-  [Constants.modes.DIRECT_SELECT]: require('./modes/direct_select'),
-  [Constants.modes.DRAW_POINT]: require('./modes/draw_point'),
-  [Constants.modes.DRAW_LINE_STRING]: require('./modes/draw_line_string'),
-  [Constants.modes.DRAW_POLYGON]: require('./modes/draw_polygon'),
-  [Constants.modes.STATIC]: require('./modes/static')
+  [Constants.modes.SIMPLE_SELECT]: SimpleSelectMode,
+  [Constants.modes.DIRECT_SELECT]: DirectSelectMode,
+  [Constants.modes.DRAW_POINT]: DrawPointMode,
+  [Constants.modes.DRAW_LINE_STRING]: DrawLineStringMode,
+  [Constants.modes.DRAW_POLYGON]: DrawPolygonMode,
+  [Constants.modes.STATIC]: StaticMode
 };
 
 module.exports = function(ctx) {
@@ -17,7 +25,7 @@ module.exports = function(ctx) {
   var mouseDownInfo = {};
   var events = {};
   var currentModeName = Constants.modes.SIMPLE_SELECT;
-  var currentMode = ModeHandler(modes.simple_select(ctx), ctx);
+  var currentMode = ModeHandler(new modes.simple_select(ctx.options, ctx.store, ctx.ui), ctx);
 
   events.drag = function(event) {
     if (isClick(mouseDownInfo, {
@@ -107,7 +115,7 @@ module.exports = function(ctx) {
       throw new Error(`${modename} is not valid`);
     }
     currentModeName = modename;
-    var mode = modebuilder(ctx, nextModeOptions);
+    var mode = new modebuilder(ctx.options, ctx.store, ctx.ui);
     currentMode = ModeHandler(mode, ctx);
 
     if (!eventOptions.silent) {

--- a/src/events.js
+++ b/src/events.js
@@ -107,8 +107,8 @@ module.exports = function(ctx) {
     ctx.store.changeZoom();
   };
 
-  function changeMode(modename, nextModeOptions, eventOptions = {}) {
-    currentMode.stop();
+  function changeMode(modename, eventOptions = {}) {
+    var modename = currentMode.changeMode(modename);
 
     var modebuilder = modes[modename];
     if (modebuilder === undefined) {

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -1,16 +1,11 @@
 var hat = require('hat');
 var Constants = require('../constants');
 
-var Feature = function(ctx, geojson) {
-  this.ctx = ctx;
+var Feature = function(geojson) {
   this.properties = geojson.properties || {};
   this.coordinates = geojson.geometry.coordinates;
   this.id = geojson.id || hat();
   this.type = geojson.geometry.type;
-};
-
-Feature.prototype.changed = function() {
-  this.ctx.store.featureChanged(this.id);
 };
 
 Feature.prototype.incomingCoords = function(coords) {

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -50,4 +50,4 @@ Feature.prototype.internal = function(mode) {
   };
 };
 
-export default Feature;
+module.exports = Feature;

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -55,4 +55,4 @@ Feature.prototype.internal = function(mode) {
   };
 };
 
-module.exports = Feature;
+export default Feature;

--- a/src/feature_types/line_string.js
+++ b/src/feature_types/line_string.js
@@ -1,7 +1,7 @@
 var Feature = require('./feature');
 
-var LineString = function(ctx, geojson) {
-  Feature.call(this, ctx, geojson);
+var LineString = function(geojson) {
+  Feature.call(this, geojson);
 };
 
 LineString.prototype = Object.create(Feature.prototype);

--- a/src/feature_types/multi_feature.js
+++ b/src/feature_types/multi_feature.js
@@ -14,8 +14,8 @@ let takeAction = (features, action, path, lng, lat) => {
   return features[idx][action](tail, lng, lat);
 };
 
-var MultiFeature = function(ctx, geojson) {
-  Feature.call(this, ctx, geojson);
+var MultiFeature = function(geojson) {
+  Feature.call(this, geojson);
 
   delete this.coordinates;
   this.model = models[geojson.geometry.type];
@@ -26,7 +26,7 @@ var MultiFeature = function(ctx, geojson) {
 MultiFeature.prototype = Object.create(Feature.prototype);
 
 MultiFeature.prototype._coordinatesToFeatures = function(coordinates) {
-  return coordinates.map(coords => new this.model(this.ctx, {
+  return coordinates.map(coords => new this.model({
     id: this.id,
     type: Constants.geojsonTypes.FEATURE,
     properties: {},

--- a/src/feature_types/point.js
+++ b/src/feature_types/point.js
@@ -1,7 +1,7 @@
 var Feature = require('./feature');
 
-var Point = function(ctx, geojson) {
-  Feature.call(this, ctx, geojson);
+var Point = function(geojson) {
+  Feature.call(this, geojson);
 };
 
 Point.prototype = Object.create(Feature.prototype);

--- a/src/feature_types/polygon.js
+++ b/src/feature_types/polygon.js
@@ -1,7 +1,7 @@
 var Feature = require('./feature');
 
-var Polygon = function(ctx, geojson) {
-  Feature.call(this, ctx, geojson);
+var Polygon = function(geojson) {
+  Feature.call(this, geojson);
   this.coordinates = this.coordinates.map(ring => ring.slice(0, -1));
 };
 

--- a/src/lib/drag_pan.js
+++ b/src/lib/drag_pan.js
@@ -1,0 +1,11 @@
+module.exports = {
+  enable(ctx) {
+    setTimeout(() => {
+      if (!ctx.map || !ctx.map.dragPan) return;
+      ctx.map.dragPan.enable();
+    }, 0);
+  },
+  disable(ctx) {
+    ctx.map.dragPan.disable();
+  }
+};

--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -22,11 +22,33 @@ var ModeHandler = function(mode, ctx) {
     }
   }
 
+  var finalNextModeName = null;
+  mode.changeMode = function(nextModeName, eventOptions = {}) {
+    var emit = finalNextModeName === null;
+    finalNextModeName = nextModeName;
+    if (emit) {
+      ctx.events.changeMode(nextModeName, eventOptions);
+      // todo: clean up...
+    }
+    else {
+      mode.onChangeMode(nextModeName, ctx.store, ctx.ui);
+    }
+    var out = finalNextModeName;
+    if (emit) {
+      finalNextModeName = null;
+    }
+    return out;
+  }
+
   var children = [];
 
   mode.appendChild = function(child) {
     children.push(child);
     ctx.container.appendChild(child);
+  }
+
+  mode.fire = function(...args) {
+    map.fire.call(map, args);
   }
 
   function delegate(action, event) {
@@ -44,10 +66,11 @@ var ModeHandler = function(mode, ctx) {
   }
 
   return {
-    render: mode.render,
-    stop: function() {
-      // todo: clean up children
-      if (mode.stop) mode.stop();
+    changeMode: function(modename) {
+      return mode.changeMode(modename);
+    },
+    render: function(geojson, render) {
+      mode.prepareAndRender(geojson, render, ctx.store, ctx.ui);
     },
     trash: function() {
       mode.onTrash();

--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -1,81 +1,78 @@
-var ModeHandler = function(mode, DrawContext) {
+import Point from 'point-geometry';
+import doubleClickZoom from './double_click_zoom';
+import dragPan from './drag_pan';
 
-  var handlers = {
-    drag: [],
-    click: [],
-    mousemove: [],
-    mousedown: [],
-    mouseup: [],
-    keydown: [],
-    keyup: []
-  };
+var ModeHandler = function(mode, ctx) {
 
-  var ctx = {
-    on: function(event, selector, fn) {
-      if (handlers[event] === undefined) {
-        throw new Error(`Invalid event type: ${event}`);
-      }
-      handlers[event].push({
-        selector: selector,
-        fn: fn
-      });
-    },
-    render: function(id) {
-      DrawContext.store.featureChanged(id);
+  mode.dragPan = function(enable) {
+    if (enable) {
+      dragPan.enable(ctx);
     }
-  };
-
-  var delegate = function (eventName, event) {
-    var handles = handlers[eventName];
-    var iHandle = handles.length;
-    while (iHandle--) {
-      var handle = handles[iHandle];
-      if (handle.selector(event)) {
-        handle.fn.call(ctx, event);
-        DrawContext.store.render();
-        DrawContext.ui.updateMapClasses();
-
-        // ensure an event is only handled once
-        // we do this to let modes have multiple overlapping selectors
-        // and relay on order of oppertations to filter
-        break;
-      }
+    else {
+      dragPan.disable(ctx);
     }
-  };
+  }
 
-  mode.start.call(ctx);
+  mode.doubleClickZoom = function(enable) {
+    if (enable) {
+      doubleClickZoom.enable(ctx);
+    }
+    else {
+      doubleClickZoom.disable(ctx);
+    }
+  }
+
+  var children = [];
+
+  mode.appendChild = function(child) {
+    children.push(child);
+    ctx.container.appendChild(child);
+  }
+
+  function delegate(action, event) {
+    console.log(action);
+    if (event.originalEvent) {
+      const rect = ctx.container.getBoundingClientRect();
+      event.mouseEventPoint = new Point(
+        event.originalEvent.clientX - rect.left - ctx.container.clientLeft,
+        event.originalEvent.clientY - rect.top - ctx.container.clientTop
+      );
+    }
+    mode[action](event, ctx.store, ctx.ui);
+    ctx.store.render();
+    ctx.ui.updateMapClasses();
+  }
 
   return {
     render: mode.render,
     stop: function() {
+      // todo: clean up children
       if (mode.stop) mode.stop();
     },
     trash: function() {
-      if (mode.trash) {
-        mode.trash();
-        DrawContext.store.render();
-      }
+      mode.onTrash();
+      ctx.store.render();
     },
     drag: function(event) {
-      delegate('drag', event);
+      delegate('onDrag', event);
     },
     click: function(event) {
-      delegate('click', event);
+      delegate('onClick', event);
     },
     mousemove: function(event) {
-      delegate('mousemove', event);
+      delegate('onMousemove', event);
     },
     mousedown: function(event) {
-      delegate('mousedown', event);
+      delegate('onMousedown', event);
     },
     mouseup: function(event) {
-      delegate('mouseup', event);
+      delegate('onMouseup', event);
     },
     keydown: function(event) {
-      delegate('keydown', event);
+      delegate('onKeydown', event);
     },
     keyup: function(event) {
-      delegate('keyup', event);
+      delegate('onKeyup', event);
     }
   };
 };

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -130,7 +130,7 @@ export default class DirectSelectMode extends ModeInterface {
     stopDragging();
   }
 
-  changeMode() {
+  onChangeMode() {
     this.doubleClickZoom(true);
   }
 

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -1,158 +1,170 @@
-var {noTarget, isOfMetaType, isInactiveFeature, isShiftDown} = require('../lib/common_selectors');
 var createSupplementaryPoints = require('../lib/create_supplementary_points');
 const constrainFeatureMovement = require('../lib/constrain_feature_movement');
 const Constants = require('../constants');
 const CommonSelectors = require('../lib/common_selectors');
 
+import ModeInterface from './mode_interface';
+
 export default class DirectSelectMode extends ModeInterface {
   constructor (options, store, ui) {
-    /// meh
+    super();
+    this.feature = store.getSelected()[0];
+
+    if (this.feature === undefined) {
+      throw new Error('A feature must be selected to enter DirectSelect mode');
+    }
+
+    if (this.feature.type === Constants.geojsonTypes.POINT) {
+      throw new TypeError('direct_select mode doesn\'t handle point features');
+    }
+
+    this.featureId = this.feature.id;
+
+    this.dragMoveLocation = null;
+    this.dragMoving = false;
+    this.canDragMove = false;
+
+    this.selectedCoordPaths = []; // todo...
+
+    this.doubleClickZoom(false);
   }
-}
 
-module.exports = function(ctx, opts) {
-  var featureId = opts.featureId;
-  var feature = ctx.store.get(featureId);
-
-  if (!feature) {
-    throw new Error('You must provide a featureId to enter direct_select mode');
+  startDragging (e) {
+    this.dragPan(false);
+    this.canDragMove = true;
+    this.dragMoveLocation = e.lngLat;
   }
 
-  if (feature.type === Constants.geojsonTypes.POINT) {
-    throw new TypeError('direct_select mode doesn\'t handle point features');
+  stopDragging (e) {
+    this.dragPan(true);
+    this.dragMoving = false;
+    this.canDragMove = false;
+    this.dragMoveLocation = null;
   }
 
-  var dragMoveLocation = opts.startPos || null;
-  var dragMoving = false;
-  var canDragMove = false;
-
-  var selectedCoordPaths = opts.coordPath ? [opts.coordPath] : [];
-
-  var onVertex = function(e) {
-    startDragging(e);
+  onVertex (e) {
+    this.startDragging(e);
     var about = e.featureTarget.properties;
-    var selectedIndex = selectedCoordPaths.indexOf(about.coord_path);
+    var selectedIndex = this.selectedCoordPaths.indexOf(about.coord_path);
     if (!isShiftDown(e) && selectedIndex === -1) {
-      selectedCoordPaths = [about.coord_path];
+      this.selectedCoordPaths = [about.coord_path];
     }
     else if (isShiftDown(e) && selectedIndex === -1) {
-      selectedCoordPaths.push(about.coord_path);
+      this.selectedCoordPaths.push(about.coord_path);
     }
-    feature.changed();
-  };
+    this.feature.changed();
+  }
 
-  var onMidpoint = function(e) {
-    startDragging(e);
+  onMidpoint (e, store) {
+    this.startDragging(e);
     var about = e.featureTarget.properties;
     feature.addCoordinate(about.coord_path, about.lng, about.lat);
-    ctx.map.fire(Constants.events.UPDATE, {
+    this.fire(Constants.events.UPDATE, {
+      action: Constants.updateActions.CHANGE_COORDINATES,
+      features: store.getSelected().map(f => f.toGeoJSON())
+    });
+    this.selectedCoordPaths = [about.coord_path];
+  }
+
+  onMouseMove (e) {
+    this.stopDragging(e);
+  }
+
+  onMousedown (e) {
+    if (CommonSelectors.isVertex(e)) {
+      return this.onVertex(e);
+    }
+
+    if (CommonSelectors.isMidpoint(e)) {
+      return this.onMidpoint(e);
+    }
+  }
+
+  onDraw (e) {
+    if (this.canDragMove) {
+      this.dragMoving = true;
+      e.originalEvent.stopPropagation();
+
+      var selectedCoords = this.selectedCoordPaths.map(coord_path => this.feature.getCoordinate(coord_path));
+      var selectedCoordPoints = selectedCoords.map(coords => ({
+        type: Constants.geojsonTypes.FEATURE,
+        properties: {},
+        geometry: {
+          type: Constants.geojsonTypes.POINT,
+          coordinates: coords
+        }
+      }));
+      var delta = {
+        lng: e.lngLat.lng - this.dragMoveLocation.lng,
+        lat: e.lngLat.lat - this.dragMoveLocation.lat
+      };
+      var constrainedDelta = constrainFeatureMovement(selectedCoordPoints, delta);
+
+      for (var i = 0; i < selectedCoords.length; i++) {
+        var coord = selectedCoords[i];
+        this.feature.updateCoordinate(this.selectedCoordPaths[i],
+          coord[0] + constrainedDelta.lng,
+          coord[1] + constrainedDelta.lat);
+      }
+
+      this.dragMoveLocation = e.lngLat;
+    }
+  }
+
+  onClick(e, store) {
+    if (CommonSelectors.noTarget(e) || CommonSelectors.isInactiveFeature(e)) {
+      store.clearSelected();
+      return this.changeMode(Constants.modes.SIMPLE_SELECT);
+    }
+
+    this.stopDragging(e);
+  }
+
+  onMouseup (e, store) {
+    if (this.dragMoving) {
+      this.fire(Constants.events.UPDATE, {
+        action: Constants.updateActions.CHANGE_COORDINATES,
+        features: store.getSelected().map(f => f.toGeoJSON())
+      });
+    }
+    stopDragging();
+  }
+
+  changeMode() {
+    this.doubleClickZoom(true);
+  }
+
+  prepareAndRender(geojson, render) {
+    if (featureId === geojson.properties.id) {
+      geojson.properties.active = Constants.activeStates.ACTIVE;
+      render(geojson);
+      createSupplementaryPoints(geojson, {
+        map: ctx.map,
+        midpoints: true,
+        selectedPaths: this.selectedCoordPaths
+      }).forEach(render);
+    }
+    else {
+      geojson.properties.active = Constants.activeStates.INACTIVE;
+      render(geojson);
+    }
+  }
+
+  onTrash(store, ui) {
+    if (this.selectedCoordPaths.length === 0) {
+      return this.changeMode(Constants.modes.SIMPLE_SELECT);
+    }
+
+    this.selectedCoordPaths.sort().reverse().forEach(id => this.feature.removeCoordinate(id));
+    this.fire(Constants.events.UPDATE, {
       action: Constants.updateActions.CHANGE_COORDINATES,
       features: ctx.store.getSelected().map(f => f.toGeoJSON())
     });
-    selectedCoordPaths = [about.coord_path];
-  };
-
-  var startDragging = function(e) {
-    ctx.map.dragPan.disable();
-    canDragMove = true;
-    dragMoveLocation = e.lngLat;
-  };
-
-  var stopDragging = function() {
-    ctx.map.dragPan.enable();
-    dragMoving = false;
-    canDragMove = false;
-    dragMoveLocation = null;
-  };
-
-  return {
-    start: function() {
-      ctx.store.setSelected(featureId);
-      this.doubleClickZoom(false);
-
-      // On mousemove that is not a drag, stop vertex movement.
-      this.on('mousemove', CommonSelectors.true, stopDragging);
-
-      this.on('mousedown', isVertex, onVertex);
-      this.on('mousedown', isMidpoint, onMidpoint);
-      this.on('drag', () => canDragMove, function(e) {
-        dragMoving = true;
-        e.originalEvent.stopPropagation();
-
-        var selectedCoords = selectedCoordPaths.map(coord_path => feature.getCoordinate(coord_path));
-        var selectedCoordPoints = selectedCoords.map(coords => ({
-          type: Constants.geojsonTypes.FEATURE,
-          properties: {},
-          geometry: {
-            type: Constants.geojsonTypes.POINT,
-            coordinates: coords
-          }
-        }));
-        var delta = {
-          lng: e.lngLat.lng - dragMoveLocation.lng,
-          lat: e.lngLat.lat - dragMoveLocation.lat
-        };
-        var constrainedDelta = constrainFeatureMovement(selectedCoordPoints, delta);
-
-        for (var i = 0; i < selectedCoords.length; i++) {
-          var coord = selectedCoords[i];
-          feature.updateCoordinate(selectedCoordPaths[i],
-            coord[0] + constrainedDelta.lng,
-            coord[1] + constrainedDelta.lat);
-        }
-
-        dragMoveLocation = e.lngLat;
-      });
-      this.on('click', CommonSelectors.true, stopDragging);
-      this.on('mouseup', CommonSelectors.true, function() {
-        if (dragMoving) {
-          ctx.map.fire(Constants.events.UPDATE, {
-            action: Constants.updateActions.CHANGE_COORDINATES,
-            features: ctx.store.getSelected().map(f => f.toGeoJSON())
-          });
-        }
-        stopDragging();
-      });
-      this.on('click', noTarget, function() {
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
-      });
-      this.on('click', isInactiveFeature, function() {
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
-      });
-    },
-    stop: function() {
-      this.doubleClickZoom(true);
-    },
-    render: function(geojson, push) {
-      if (featureId === geojson.properties.id) {
-        geojson.properties.active = Constants.activeStates.ACTIVE;
-        push(geojson);
-        createSupplementaryPoints(geojson, {
-          map: ctx.map,
-          midpoints: true,
-          selectedPaths: selectedCoordPaths
-        }).forEach(push);
-      }
-      else {
-        geojson.properties.active = Constants.activeStates.INACTIVE;
-        push(geojson);
-      }
-    },
-    trash: function() {
-      if (selectedCoordPaths.length === 0) {
-        return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { features: [feature] });
-      }
-
-      selectedCoordPaths.sort().reverse().forEach(id => feature.removeCoordinate(id));
-      ctx.map.fire(Constants.events.UPDATE, {
-        action: Constants.updateActions.CHANGE_COORDINATES,
-        features: ctx.store.getSelected().map(f => f.toGeoJSON())
-      });
-      selectedCoordPaths = [];
-      if (feature.isValid() === false) {
-        ctx.store.delete([featureId]);
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, null);
-      }
+    this.selectedCoordPaths = [];
+    if (this.feature.isValid() === false) {
+      store.delete([featureId]);
+      this.changeMode(Constants.modes.SIMPLE_SELECT);
     }
-  };
-};
+  }
+
+}

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -1,12 +1,14 @@
 var {noTarget, isOfMetaType, isInactiveFeature, isShiftDown} = require('../lib/common_selectors');
 var createSupplementaryPoints = require('../lib/create_supplementary_points');
 const constrainFeatureMovement = require('../lib/constrain_feature_movement');
-const doubleClickZoom = require('../lib/double_click_zoom');
 const Constants = require('../constants');
 const CommonSelectors = require('../lib/common_selectors');
 
-const isVertex = isOfMetaType(Constants.meta.VERTEX);
-const isMidpoint = isOfMetaType(Constants.meta.MIDPOINT);
+export default class DirectSelectMode extends ModeInterface {
+  constructor (options, store, ui) {
+    /// meh
+  }
+}
 
 module.exports = function(ctx, opts) {
   var featureId = opts.featureId;
@@ -66,7 +68,7 @@ module.exports = function(ctx, opts) {
   return {
     start: function() {
       ctx.store.setSelected(featureId);
-      doubleClickZoom.disable(ctx);
+      this.doubleClickZoom(false);
 
       // On mousemove that is not a drag, stop vertex movement.
       this.on('mousemove', CommonSelectors.true, stopDragging);
@@ -119,7 +121,7 @@ module.exports = function(ctx, opts) {
       });
     },
     stop: function() {
-      doubleClickZoom.enable(ctx);
+      this.doubleClickZoom(true);
     },
     render: function(geojson, push) {
       if (featureId === geojson.properties.id) {

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -7,7 +7,7 @@ const createVertex = require('../lib/create_vertex');
 import ModeInterface from './mode_interface';
 
 export default class DrawLineStringMode extends ModeInterface {
-  constructor(store, ui) {
+  constructor(options, store, ui) {
     super();
     this.line = new LineString({
       type: Constants.geojsonTypes.FEATURE,
@@ -64,7 +64,7 @@ export default class DrawLineStringMode extends ModeInterface {
     this.changeMode(Constants.modes.SIMPLE_SELECT);
   }
 
-  changeMode(nextModeName, store, ui) {
+  onChangeMode(nextModeName, store, ui) {
     this.doubleClickZoom(true);
     ui.setActiveButton();
     if (store.get(this.line.id) === undefined) return;

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -6,7 +6,7 @@ const Constants = require('../constants');
 const createVertex = require('../lib/create_vertex');
 
 module.exports = function(ctx) {
-  const line = new LineString(ctx, {
+  const line = new LineString({
     type: Constants.geojsonTypes.FEATURE,
     properties: {},
     geometry: {

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -1,14 +1,13 @@
 const CommonSelectors = require('../lib/common_selectors');
 const LineString = require('../feature_types/line_string');
 const isEventAtCoordinates = require('../lib/is_event_at_coordinates');
-const doubleClickZoom = require('../lib/double_click_zoom');
 const Constants = require('../constants');
 const createVertex = require('../lib/create_vertex');
 
 import ModeInterface from './mode_interface';
 
-export default class DrawPointMode extends ModeInterface {
-  constructor(store, ui, map) {
+export default class DrawLineStringMode extends ModeInterface {
+  constructor(store, ui) {
     this.line = new LineString({
       type: Constants.geojsonTypes.FEATURE,
       properties: {},
@@ -22,7 +21,7 @@ export default class DrawPointMode extends ModeInterface {
 
     store.add(this.line);
     store.clearSelected();
-    doubleClickZoom.disable({map});
+    this.doubleClickZoom(false);
     ui.queueMapClasses({ mouse: Constants.cursors.ADD });
     ui.setActiveButton(Constants.types.LINE);
   }
@@ -64,8 +63,8 @@ export default class DrawPointMode extends ModeInterface {
     this.changeMode(Constants.modes.SIMPLE_SELECT);
   }
 
-  changeMode(nextModeName, store, ui, map) {
-    doubleClickZoom.enable({map});
+  changeMode(nextModeName, store, ui) {
+    this.doubleClickZoom(true);
     ui.setActiveButton();
     if (store.get(this.line.id) === undefined) return;
 
@@ -73,7 +72,7 @@ export default class DrawPointMode extends ModeInterface {
     this.line.removeCoordinate(`${this.currentVertexPosition}`);
 
     if (this.line.isValid()) {
-      map.fire(Constants.events.CREATE, {
+      this.fire(Constants.events.CREATE, {
         features: [line.toGeoJSON()]
       });
     }

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -8,6 +8,7 @@ import ModeInterface from './mode_interface';
 
 export default class DrawLineStringMode extends ModeInterface {
   constructor(store, ui) {
+    super();
     this.line = new LineString({
       type: Constants.geojsonTypes.FEATURE,
       properties: {},

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -6,6 +6,7 @@ import ModeInterface from './mode_interface';
 
 export default class DrawPointMode extends ModeInterface {
   constructor(store, ui) {
+    super();
     this.point = new Point({
       type: Constants.geojsonTypes.FEATURE,
       properties: {},

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -22,10 +22,10 @@ export default class DrawPointMode extends ModeInterface {
     ui.setActiveButton(Constants.types.POINT);
   }
 
-  onClick(e, store, ui, map) {
+  onClick(e, store, ui) {
     ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
     point.updateCoordinate('', e.lngLat.lng, e.lngLat.lat);
-    map.fire(Constants.events.CREATE, {
+    this.fire(Constants.events.CREATE, {
       features: [point.toGeoJSON()]
     });
     store.setSelected([point.id]);

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -22,10 +22,10 @@ export default class DrawPointMode extends ModeInterface {
     ui.setActiveButton(Constants.types.POINT);
   }
 
-  onClick(e, store, ui) {
+  onClick(e, store, ui, map) {
     ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
     point.updateCoordinate('', e.lngLat.lng, e.lngLat.lat);
-    ctx.map.fire(Constants.events.CREATE, {
+    map.fire(Constants.events.CREATE, {
       features: [point.toGeoJSON()]
     });
     store.setSelected([point.id]);
@@ -39,9 +39,14 @@ export default class DrawPointMode extends ModeInterface {
     }
   }
 
-  changeMode(nextModeName, revertChanges, store, ui) {
+  onTrash() {
+    store.delete([this.point.id], { silent: true });
+    this.changeMode(Constants.modes.SIMPLE_SELECT);
+  }
+
+  changeMode(nextModeName, store, ui) {
     ui.setActiveButton();
-    if (revertChanges || !this.point.getCoordinate().length) {
+    if (!this.point.getCoordinate().length) {
       store.delete([point.id], {silent: true});
     }
   }

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -5,7 +5,7 @@ const Constants = require('../constants');
 import ModeInterface from './mode_interface';
 
 export default class DrawPointMode extends ModeInterface {
-  constructor(store, ui) {
+  constructor(options, store, ui) {
     super();
     this.point = new Point({
       type: Constants.geojsonTypes.FEATURE,
@@ -16,7 +16,7 @@ export default class DrawPointMode extends ModeInterface {
       }
     });
 
-    store.add(point);
+    store.add(this.point);
 
     store.clearSelected();
     ui.queueMapClasses({ mouse: Constants.cursors.ADD });
@@ -25,11 +25,11 @@ export default class DrawPointMode extends ModeInterface {
 
   onClick(e, store, ui) {
     ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
-    point.updateCoordinate('', e.lngLat.lng, e.lngLat.lat);
+    this.point.updateCoordinate('', e.lngLat.lng, e.lngLat.lat);
     this.fire(Constants.events.CREATE, {
-      features: [point.toGeoJSON()]
+      features: [this.point.toGeoJSON()]
     });
-    store.setSelected([point.id]);
+    store.setSelected([this.point.id]);
     this.changeMode(Constants.modes.SIMPLE_SELECT);
   }
 
@@ -45,10 +45,17 @@ export default class DrawPointMode extends ModeInterface {
     this.changeMode(Constants.modes.SIMPLE_SELECT);
   }
 
-  changeMode(nextModeName, store, ui) {
+  onChangeMode(nextModeName, store, ui) {
     ui.setActiveButton();
     if (!this.point.getCoordinate().length) {
-      store.delete([point.id], {silent: true});
+      store.delete([this.point.id], {silent: true});
     }
+  }
+
+  prepareAndRender(geojson, render) {
+    const isActivePoint = geojson.properties.id === this.point.id;
+    geojson.properties.active = (isActivePoint) ? Constants.activeStates.ACTIVE : Constants.activeStates.INACTIVE;
+    if (!isActivePoint) return render(geojson);
+    // Never render the point we're drawing
   }
 }

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -2,61 +2,47 @@ const CommonSelectors = require('../lib/common_selectors');
 const Point = require('../feature_types/point');
 const Constants = require('../constants');
 
-module.exports = function(ctx) {
+import ModeInterface from './mode_interface';
 
-  const point = new Point(ctx, {
-    type: Constants.geojsonTypes.FEATURE,
-    properties: {},
-    geometry: {
-      type: Constants.geojsonTypes.POINT,
-      coordinates: []
-    }
-  });
+export default class DrawPointMode extends ModeInterface {
+  constructor(store, ui) {
+    this.point = new Point({
+      type: Constants.geojsonTypes.FEATURE,
+      properties: {},
+      geometry: {
+        type: Constants.geojsonTypes.POINT,
+        coordinates: []
+      }
+    });
 
-  if (ctx._test) ctx._test.point = point;
+    store.add(point);
 
-  ctx.store.add(point);
-
-  function stopDrawingAndRemove() {
-    ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
-    ctx.store.delete([point.id], { silent: true });
+    store.clearSelected();
+    ui.queueMapClasses({ mouse: Constants.cursors.ADD });
+    ui.setActiveButton(Constants.types.POINT);
   }
 
-  function handleClick(e) {
-    ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
+  onClick(e, store, ui) {
+    ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
     point.updateCoordinate('', e.lngLat.lng, e.lngLat.lat);
     ctx.map.fire(Constants.events.CREATE, {
       features: [point.toGeoJSON()]
     });
-    ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [point.id] });
+    store.setSelected([point.id]);
+    this.changeMode(Constants.modes.SIMPLE_SELECT);
   }
 
-  return {
-    start() {
-      ctx.store.clearSelected();
-      ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
-      ctx.ui.setActiveButton(Constants.types.POINT);
-      this.on('click', CommonSelectors.true, handleClick);
-      this.on('keyup', CommonSelectors.isEscapeKey, stopDrawingAndRemove);
-      this.on('keyup', CommonSelectors.isEnterKey, stopDrawingAndRemove);
-    },
-
-    stop() {
-      ctx.ui.setActiveButton();
-      if (!point.getCoordinate().length) {
-        ctx.store.delete([point.id], { silent: true });
-      }
-    },
-
-    render(geojson, callback) {
-      const isActivePoint = geojson.properties.id === point.id;
-      geojson.properties.active = (isActivePoint) ? Constants.activeStates.ACTIVE : Constants.activeStates.INACTIVE;
-      if (!isActivePoint) return callback(geojson);
-      // Never render the point we're drawing
-    },
-
-    trash() {
-      stopDrawingAndRemove();
+  onKeyup(e, store) {
+    if (CommonSelectors.isEscapeKey(e) || CommonSelectors.isEnterKey(e)) {
+      store.delete([this.point.id], {silent: true});
+      this.changeMode(Constants.modes.SIMPLE_SELECT);
     }
-  };
-};
+  }
+
+  changeMode(nextModeName, revertChanges, store, ui) {
+    ui.setActiveButton();
+    if (revertChanges || !this.point.getCoordinate().length) {
+      store.delete([point.id], {silent: true});
+    }
+  }
+}

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -7,7 +7,7 @@ const createVertex = require('../lib/create_vertex');
 
 module.exports = function(ctx) {
 
-  const polygon = new Polygon(ctx, {
+  const polygon = new Polygon({
     type: Constants.geojsonTypes.FEATURE,
     properties: {},
     geometry: {

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -4,8 +4,11 @@ const Constants = require('../constants');
 const isEventAtCoordinates = require('../lib/is_event_at_coordinates');
 const createVertex = require('../lib/create_vertex');
 
+import ModeInterface from './mode_interface';
+
 export default class DrawPolygonMode extends ModeInterface {
   constructor (store, ui) {
+    super();
     this.currentVertexPosition = 0;
     this.polygon = new Polygon({
       type: Constants.geojsonTypes.FEATURE,

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -7,7 +7,7 @@ const createVertex = require('../lib/create_vertex');
 import ModeInterface from './mode_interface';
 
 export default class DrawPolygonMode extends ModeInterface {
-  constructor (store, ui) {
+  constructor (options, store, ui) {
     super();
     this.currentVertexPosition = 0;
     this.polygon = new Polygon({
@@ -66,7 +66,7 @@ export default class DrawPolygonMode extends ModeInterface {
     this.changeMode(Constants.modes.SIMPLE_SELECT);
   }
 
-  changeMode (nextModeName, store, ui) {
+  onChangeMode (nextModeName, store, ui) {
     ui.queueMapClasses({ mouse: Constants.cursors.NONE });
     this.doubleClickZoom(true);
     ui.setActiveButton();

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -1,127 +1,131 @@
 const CommonSelectors = require('../lib/common_selectors');
 const Polygon = require('../feature_types/polygon');
-const doubleClickZoom = require('../lib/double_click_zoom');
 const Constants = require('../constants');
 const isEventAtCoordinates = require('../lib/is_event_at_coordinates');
 const createVertex = require('../lib/create_vertex');
 
-module.exports = function(ctx) {
+export default class DrawPolygonMode extends ModeInterface {
+  constructor (store, ui) {
+    this.currentVertexPosition = 0;
+    this.polygon = new Polygon({
+      type: Constants.geojsonTypes.FEATURE,
+      properties: {},
+      geometry: {
+        type: Constants.geojsonTypes.POLYGON,
+        coordinates: [[]]
+      }
+    });
 
-  const polygon = new Polygon({
-    type: Constants.geojsonTypes.FEATURE,
-    properties: {},
-    geometry: {
-      type: Constants.geojsonTypes.POLYGON,
-      coordinates: [[]]
+    store.add(this.polygon);
+    store.clearSelected();
+    this.doubleClickZoom(false);
+    ui.queueMapClasses({ mouse: Constants.cursors.ADD });
+    ui.setActiveButton(Constants.types.POLYGON);
+  }
+
+  onMousemove (e, store, ui) {
+    this.polygon.updateCoordinate(`0.${this.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
+    if (CommonSelectors.isVertex(e)) {
+      ui.queueMapClasses({ mouse: Constants.cursors.POINTER });
     }
-  });
-  let currentVertexPosition = 0;
+  }
 
-  if (ctx._test) ctx._test.polygon = polygon;
-
-  ctx.store.add(polygon);
-
-  return {
-    start() {
-      ctx.store.clearSelected();
-      doubleClickZoom.disable(ctx);
-      ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
-      ctx.ui.setActiveButton(Constants.types.POLYGON);
-      this.on('mousemove', CommonSelectors.true, e => {
-        polygon.updateCoordinate(`0.${currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
-        if (CommonSelectors.isVertex(e)) {
-          ctx.ui.queueMapClasses({ mouse: Constants.cursors.POINTER });
-        }
-      });
-      this.on('click', CommonSelectors.true, (e) => {
-        if (currentVertexPosition > 0 && isEventAtCoordinates(e, polygon.coordinates[0][currentVertexPosition - 1])) {
-          return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [polygon.id] });
-        }
-        ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
-        polygon.updateCoordinate(`0.${currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
-        currentVertexPosition++;
-      });
-      this.on('click', CommonSelectors.isVertex, () => {
-        return ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [polygon.id] });
-      });
-      this.on('keyup', CommonSelectors.isEscapeKey, () => {
-        ctx.store.delete([polygon.id], { silent: true });
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
-      });
-      this.on('keyup', CommonSelectors.isEnterKey, () => {
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [polygon.id] });
-      });
-    },
-
-    stop: function() {
-      ctx.ui.queueMapClasses({ mouse: Constants.cursors.NONE });
-      doubleClickZoom.enable(ctx);
-      ctx.ui.setActiveButton();
-
-      // check to see if we've deleted this feature
-      if (ctx.store.get(polygon.id) === undefined) return;
-
-      //remove last added coordinate
-      polygon.removeCoordinate(`0.${currentVertexPosition}`);
-      if (polygon.isValid()) {
-        ctx.map.fire(Constants.events.CREATE, {
-          features: [polygon.toGeoJSON()]
-        });
-      }
-      else {
-        ctx.store.delete([polygon.id], { silent: true });
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, {}, { silent: true });
-      }
-    },
-
-    render(geojson, callback) {
-      const isActivePolygon = geojson.properties.id === polygon.id;
-      geojson.properties.active = (isActivePolygon) ? Constants.activeStates.ACTIVE : Constants.activeStates.INACTIVE;
-      if (!isActivePolygon) return callback(geojson);
-
-      // Don't render a polygon until it has two positions
-      // (and a 3rd which is just the first repeated)
-      if (geojson.geometry.coordinates.length === 0) return;
-
-      const coordinateCount = geojson.geometry.coordinates[0].length;
-
-      // If we have fewer than two positions (plus the closer),
-      // it's not yet a shape to render
-      if (coordinateCount < 3) return;
-
-      geojson.properties.meta = Constants.meta.FEATURE;
-
-      if (coordinateCount > 4) {
-        // Add a start position marker to the map, clicking on this will finish the feature
-        // This should only be shown when we're in a valid spot
-        callback(createVertex(polygon.id, geojson.geometry.coordinates[0][0], '0.0', false));
-        let endPos = geojson.geometry.coordinates[0].length - 3;
-        callback(createVertex(polygon.id, geojson.geometry.coordinates[0][endPos], `0.${endPos}`, false));
-      }
-
-      // If we have more than two positions (plus the closer),
-      // render the Polygon
-      if (coordinateCount > 3) {
-        return callback(geojson);
-      }
-
-      // If we've only drawn two positions (plus the closer),
-      // make a LineString instead of a Polygon
-      const lineCoordinates = [
-        [geojson.geometry.coordinates[0][0][0], geojson.geometry.coordinates[0][0][1]], [geojson.geometry.coordinates[0][1][0], geojson.geometry.coordinates[0][1][1]]
-      ];
-      return callback({
-        type: Constants.geojsonTypes.FEATURE,
-        properties: geojson.properties,
-        geometry: {
-          coordinates: lineCoordinates,
-          type: Constants.geojsonTypes.LINE_STRING
-        }
-      });
-    },
-    trash() {
-      ctx.store.delete([polygon.id], { silent: true });
-      ctx.events.changeMode(Constants.modes.SIMPLE_SELECT);
+  onClick (e, store, ui) {
+    if (CommonSelectors.isVertex(e)) {
+      store.setSelected([this.polygon.id]);
+      return this.changeMode(Constants.modes.SIMPLE_SELECT);
     }
-  };
-};
+
+    if (this.currentVertexPosition > 0 && isEventAtCoordinates(e, this.polygon.coordinates[0][this.currentVertexPosition - 1])) {
+      store.setSelected([this.polygon.id]);
+      return this.changeMode(Constants.modes.SIMPLE_SELECT);
+    }
+
+    ui.queueMapClasses({ mouse: Constants.cursors.ADD });
+    this.polygon.updateCoordinate(`0.${this.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
+    this.currentVertexPosition++;
+  }
+
+  onKeyup (e, store) {
+    if (CommonSelectors.isEscapeKey(e)) {
+      store.delete([this.polygon.id], { silent: true});
+      return this.changeMode(Constants.modes.SIMPLE_SELECT);
+    }
+
+    if (CommonSelectors.isEnterKey(e)) {
+      store.setSelected([this.polygon.id]);
+      return this.changeMode(Constants.modes.SIMPLE_SELECT);
+    }
+  }
+
+  onTrash(store) {
+    store.delete([this.polygon.id], { silent: true });
+    this.changeMode(Constants.modes.SIMPLE_SELECT);
+  }
+
+  changeMode (nextModeName, store, ui) {
+    ui.queueMapClasses({ mouse: Constants.cursors.NONE });
+    this.doubleClickZoom(true);
+    ui.setActiveButton();
+
+    // check to see if we've deleted this feature
+    if(store.get(this.polygon.id) === undefined) return;
+
+   //remove last added coordinate
+    this.polygon.removeCoordinate(`0.${currentVertexPosition}`);
+    if (this.polygon.isValid()) {
+      this.fire(Constants.events.CREATE, {
+        features: [this.polygon.toGeoJSON()]
+      });
+    }
+    else {
+      store.delete([this.polygon.id], { silent: true });
+      this.changeMode(Constants.modes.SIMPLE_SELECT, {}, { silent: true });
+    }
+  }
+  prepareAndRender(geojson, render) {
+    const isActivePolygon = geojson.properties.id === this.polygon.id;
+    geojson.properties.active = (isActivePolygon) ? Constants.activeStates.ACTIVE : Constants.activeStates.INACTIVE;
+    if (!isActivePolygon) return render(geojson);
+
+    // Don't render a polygon until it has two positions
+    // (and a 3rd which is just the first repeated)
+    if (geojson.geometry.coordinates.length === 0) return;
+
+    const coordinateCount = geojson.geometry.coordinates[0].length;
+
+    // If we have fewer than two positions (plus the closer),
+    // it's not yet a shape to render
+    if (coordinateCount < 3) return;
+
+    geojson.properties.meta = Constants.meta.FEATURE;
+
+    if (coordinateCount > 4) {
+      // Add a start position marker to the map, clicking on this will finish the feature
+      // This should only be shown when we're in a valid spot
+      render(createVertex(this.polygon.id, geojson.geometry.coordinates[0][0], '0.0', false));
+      let endPos = geojson.geometry.coordinates[0].length - 3;
+      render(createVertex(this.polygon.id, geojson.geometry.coordinates[0][endPos], `0.${endPos}`, false));
+    }
+
+    // If we have more than two positions (plus the closer),
+    // render the Polygon
+    if (coordinateCount > 3) {
+      return render(geojson);
+    }
+
+    // If we've only drawn two positions (plus the closer),
+    // make a LineString instead of a Polygon
+    const lineCoordinates = [
+      [geojson.geometry.coordinates[0][0][0], geojson.geometry.coordinates[0][0][1]], [geojson.geometry.coordinates[0][1][0], geojson.geometry.coordinates[0][1][1]]
+    ];
+    return render({
+      type: Constants.geojsonTypes.FEATURE,
+      properties: geojson.properties,
+      geometry: {
+        coordinates: lineCoordinates,
+        type: Constants.geojsonTypes.LINE_STRING
+      }
+    });
+  }
+}

--- a/src/modes/mode_interface.js
+++ b/src/modes/mode_interface.js
@@ -5,8 +5,10 @@
  ************************
  * store {object} - is the store object (normally ctx.store)
  * ui {object} - is the ui object (normally ctx.ui)
- * map {object} - the mapbox-gl-js map object
  * event {object} - is the event that triggered this handler
+      * mapPoint - a point that represents where the mouse is in pixel space
+      * featureTarget - the feature under the mouse
+      * originalEvent - the event that triggered this event
  * nextModeName {string} - the name of the mode being transitioned too
  * revertChanges {boolean} - if ture, the mode should try to undo its changes
  * geojson {object} - is the geojson representation of an internal feature.
@@ -17,17 +19,23 @@
  */
 
 export default class ModeInterface {
-  constructor() {} // store, ui, map
-  onClick () {} // event, store, ui, map
-  onDrag () {} // event, store, ui, map
-  onMousemove () {} // event, store, ui, map
-  onMousedown () {} // event, store, ui, map
-  onMouseup () {} // event, store, ui, map
-  onKeydown () {} // event, store, ui, map
-  onKeyup () {} // event, store, ui, map
-  onTrash() {} // store, ui, map
-  changeMode () {} // nextModeName, store, ui, map
-  prepareAndRender () { // geojson, render, store, ui, map
+  constructor() {} // store, ui
+  onClick () {} // event, store, ui
+  onDrag () {} // event, store, ui
+  onMousemove () {} // event, store, ui
+  onMousedown () {} // event, store, ui
+  onMouseup () {} // event, store, ui
+  onKeydown () {} // event, store, ui
+  onKeyup () {} // event, store, ui
+  onTrash() {} // store, ui
+  changeMode () {} // nextModeName, store, ui
+  prepareAndRender () { // geojson, render, store, ui
     throw new Error('A mode must implement prepareAndRender');
   }
 }
+
+// this.doubleClickZoom(enable) if ture, set to enabled. If false, set to disabled.
+// this.dragPan(enable) if ture, set to enabled. If false, set to disabled.
+// events need to have points on them based on the container (mouseEventPoint(e.originalEvent, ctx.container);)
+// this.appendChild() should add a dom node to the screen that will be cleaned up on mode change
+// this.fire fires an event

--- a/src/modes/mode_interface.js
+++ b/src/modes/mode_interface.js
@@ -1,0 +1,31 @@
+
+
+/******
+ * Overview of the arguments of ModeInterface functions
+ ************************
+ * store {object} - is the store object (normally ctx.store)
+ * ui {object} - is the ui object (normally ctx.ui)
+ * event {object} - is the event that triggered this handler
+ * nextModeName {string} - the name of the mode being transitioned too
+ * revertChanges {boolean} - if ture, the mode should try to undo its changes
+ * geojson {object} - is the geojson representation of an internal feature.
+ *     This MUST only have properties that match those covered
+ *     in the `Styling Draw` section of the documentation
+ * render {function} -  this function takes one geojson feature
+ *     that matches the `Styling Draw` spec and adds it to the map
+ */
+
+export default class ModeInterface {
+  constructor() {} // store, ui
+  onClick () {} // event, store, ui
+  onDrag () {} // event, store, ui
+  onMousemove () {} // event, store, ui
+  onMousedown () {} // event, store, ui
+  onMouseup () {} // event, store, ui
+  onKeydown () {} // event, store, ui
+  onKeyup () {} // event, store, ui
+  changeMode () {} // nextModeName, revertChanges, store, ui
+  prepareAndRender () { // geojson, render, store, ui
+    throw new Error('A mode must implement prepareAndRender');
+  }
+}

--- a/src/modes/mode_interface.js
+++ b/src/modes/mode_interface.js
@@ -19,7 +19,7 @@
  */
 
 export default class ModeInterface {
-  constructor() {} // store, ui
+  constructor() {} // options, store, ui
   onClick () {} // event, store, ui
   onDrag () {} // event, store, ui
   onMousemove () {} // event, store, ui
@@ -39,3 +39,23 @@ export default class ModeInterface {
 // events need to have points on them based on the container (mouseEventPoint(e.originalEvent, ctx.container);)
 // this.appendChild() should add a dom node to the screen that will be cleaned up on mode change
 // this.fire fires an event
+
+
+// store.add
+// store.getSelectedIds()
+// store.getSelected()
+// store.clearSelected()
+// store.setSelected()
+// store.featureChanged()
+// store.isSelected()
+// store.get()
+// store.deselect()
+// store.featuresAt()
+// store.select()
+// store.delete()
+
+
+
+
+
+

--- a/src/modes/mode_interface.js
+++ b/src/modes/mode_interface.js
@@ -5,6 +5,7 @@
  ************************
  * store {object} - is the store object (normally ctx.store)
  * ui {object} - is the ui object (normally ctx.ui)
+ * map {object} - the mapbox-gl-js map object
  * event {object} - is the event that triggered this handler
  * nextModeName {string} - the name of the mode being transitioned too
  * revertChanges {boolean} - if ture, the mode should try to undo its changes
@@ -16,16 +17,17 @@
  */
 
 export default class ModeInterface {
-  constructor() {} // store, ui
-  onClick () {} // event, store, ui
-  onDrag () {} // event, store, ui
-  onMousemove () {} // event, store, ui
-  onMousedown () {} // event, store, ui
-  onMouseup () {} // event, store, ui
-  onKeydown () {} // event, store, ui
-  onKeyup () {} // event, store, ui
-  changeMode () {} // nextModeName, revertChanges, store, ui
-  prepareAndRender () { // geojson, render, store, ui
+  constructor() {} // store, ui, map
+  onClick () {} // event, store, ui, map
+  onDrag () {} // event, store, ui, map
+  onMousemove () {} // event, store, ui, map
+  onMousedown () {} // event, store, ui, map
+  onMouseup () {} // event, store, ui, map
+  onKeydown () {} // event, store, ui, map
+  onKeyup () {} // event, store, ui, map
+  onTrash() {} // store, ui, map
+  changeMode () {} // nextModeName, store, ui, map
+  prepareAndRender () { // geojson, render, store, ui, map
     throw new Error('A mode must implement prepareAndRender');
   }
 }

--- a/src/modes/mode_interface.js
+++ b/src/modes/mode_interface.js
@@ -28,7 +28,7 @@ export default class ModeInterface {
   onKeydown () {} // event, store, ui
   onKeyup () {} // event, store, ui
   onTrash() {} // store, ui
-  changeMode () {} // nextModeName, store, ui
+  onChangeMode () {} // nextModeName, store, ui
   prepareAndRender () { // geojson, render, store, ui
     throw new Error('A mode must implement prepareAndRender');
   }

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -5,6 +5,8 @@ const StringSet = require('../lib/string_set');
 const moveFeatures = require('../lib/move_features');
 const Constants = require('../constants');
 
+import ModeInterface from './mode_interface';
+
 const getUniqueIds = function(allFeatures) {
   if (!allFeatures.length) return [];
   const ids = allFeatures.map(s => s.properties.id)
@@ -19,6 +21,7 @@ const getUniqueIds = function(allFeatures) {
 
 export default class SimpleSelectMode extends ModeInterface {
   constructor (options, store, ui) {
+    super();
     this.boxSelectIsOn = options.boxSelect;
     this.dragMoveLocation = null;
     this.boxSelectStartLocation = null;
@@ -103,7 +106,7 @@ export default class SimpleSelectMode extends ModeInterface {
       this.stopExtendedInteractions();
       this.dragPan(false);
       // Enable box select
-      this.boxSelectStartLocation = e.mapPoint;
+      this.boxSelectStartLocation = e.mouseEventPoint;
       this.canBoxSelect = true;
     }
   }
@@ -177,16 +180,17 @@ export default class SimpleSelectMode extends ModeInterface {
       if (!this.boxSelectElement) {
         this.boxSelectElement = document.createElement('div');
         this.boxSelectElement.classList.add(Constants.classes.BOX_SELECT);
-        this.appendChild(boxSelectElement);
+        this.appendChild(this.boxSelectElement);
       }
 
       // Adjust the box node's width and xy position
-      const current = e.mousePoint;
+      const current = e.mouseEventPoint;
       const minX = Math.min(this.boxSelectStartLocation.x, current.x);
       const maxX = Math.max(this.boxSelectStartLocation.x, current.x);
       const minY = Math.min(this.boxSelectStartLocation.y, current.y);
       const maxY = Math.max(this.boxSelectStartLocation.y, current.y);
       const translateValue = `translate(${minX}px, ${minY}px)`;
+      console.log(translateValue);
       this.boxSelectElement.style.transform = translateValue;
       this.boxSelectElement.style.WebkitTransform = translateValue;
       this.boxSelectElement.style.width = `${maxX - minX}px`;
@@ -207,7 +211,7 @@ export default class SimpleSelectMode extends ModeInterface {
     if (this.boxSelecting) {
       const bbox = [
         this.boxSelectStartLocation,
-        e.mousePoint
+        e.mouseEventPoint
       ];
       const featuresInBox = store.featuresAt(bbox);
       const idsToSelect = getUniqueIds(featuresInBox)
@@ -219,7 +223,7 @@ export default class SimpleSelectMode extends ModeInterface {
         ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
       }
     }
-    return stopExtendedInteractions();
+    return this.stopExtendedInteractions();
   }
 
   prepareAndRender(geojson, render, store) {

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -46,7 +46,7 @@ export default class SimpleSelectMode extends ModeInterface {
     this.canDragMove = false;
   }
 
-  changeMode (nextModeName, store, ui) {
+  onChangeMode (nextModeName, store, ui) {
     this.doubleClickZoom(true);
   }
 
@@ -163,8 +163,8 @@ export default class SimpleSelectMode extends ModeInterface {
       e.originalEvent.stopPropagation();
 
       const delta = {
-        lng: e.lngLat.lng - dragMoveLocation.lng,
-        lat: e.lngLat.lat - dragMoveLocation.lat
+        lng: e.lngLat.lng - this.dragMoveLocation.lng,
+        lat: e.lngLat.lat - this.dragMoveLocation.lat
       };
 
       moveFeatures(store.getSelected(), delta);
@@ -205,7 +205,7 @@ export default class SimpleSelectMode extends ModeInterface {
         action: Constants.updateActions.MOVE,
         features: store.getSelected().map(f => f.toGeoJSON())
       });
-      return stopExtendedInteractions();
+      return this.stopExtendedInteractions();
     }
 
     if (this.boxSelecting) {

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -1,241 +1,238 @@
 const CommonSelectors = require('../lib/common_selectors');
 const mouseEventPoint = require('../lib/mouse_event_point');
-const featuresAt = require('../lib/features_at');
 const createSupplementaryPoints = require('../lib/create_supplementary_points');
 const StringSet = require('../lib/string_set');
-const doubleClickZoom = require('../lib/double_click_zoom');
 const moveFeatures = require('../lib/move_features');
 const Constants = require('../constants');
 
-module.exports = function(ctx, options = {}) {
-  let dragMoveLocation = null;
-  let boxSelectStartLocation = null;
-  let boxSelectElement;
-  let boxSelecting = false;
-  let canBoxSelect = false;
-  let dragMoving = false;
-  let canDragMove = false;
+const getUniqueIds = function(allFeatures) {
+  if (!allFeatures.length) return [];
+  const ids = allFeatures.map(s => s.properties.id)
+    .filter(id => id !== undefined)
+    .reduce((memo, id) => {
+      memo.add(id);
+      return memo;
+    }, new StringSet());
 
-  const initiallySelectedFeatureIds = options.featureIds || [];
-
-  const getUniqueIds = function(allFeatures) {
-    if (!allFeatures.length) return [];
-    const ids = allFeatures.map(s => s.properties.id)
-      .filter(id => id !== undefined)
-      .reduce((memo, id) => {
-        memo.add(id);
-        return memo;
-      }, new StringSet());
-
-    return ids.values();
-  };
-
-  const stopExtendedInteractions = function() {
-    if (boxSelectElement) {
-      if (boxSelectElement.parentNode) boxSelectElement.parentNode.removeChild(boxSelectElement);
-      boxSelectElement = null;
-    }
-
-    ctx.map.dragPan.enable();
-
-    boxSelecting = false;
-    canBoxSelect = false;
-    dragMoving = false;
-    canDragMove = false;
-  };
-
-  return {
-    stop: function() {
-      doubleClickZoom.enable(ctx);
-    },
-    start: function() {
-      // Select features that should start selected,
-      // probably passed in from a `draw_*` mode
-      if (ctx.store) ctx.store.setSelected(initiallySelectedFeatureIds.filter(id => {
-        return ctx.store.get(id) !== undefined;
-      }));
-
-      // Any mouseup should stop box selecting and dragMoving
-      this.on('mouseup', CommonSelectors.true, stopExtendedInteractions);
-
-      // On mousemove that is not a drag, stop extended interactions.
-      // This is useful if you drag off the canvas, release the button,
-      // then move the mouse back over the canvas --- we don't the
-      // interaction to continue (but we do let it continue if you held
-      // the mouse button that whole time)
-      this.on('mousemove', CommonSelectors.true, stopExtendedInteractions);
-
-      // Click (with or without shift) on no feature
-      this.on('click', CommonSelectors.noTarget, function() {
-        // Clear the re-render selection
-        const wasSelected = ctx.store.getSelectedIds();
-        if (wasSelected.length) {
-          ctx.store.clearSelected();
-          wasSelected.forEach(id => this.render(id));
-        }
-        doubleClickZoom.enable(ctx);
-        stopExtendedInteractions();
-      });
-
-      // Click (with or without shift) on a vertex
-      this.on('click', CommonSelectors.isOfMetaType(Constants.meta.VERTEX), function(e) {
-        // Enter direct select mode
-        ctx.events.changeMode(Constants.modes.DIRECT_SELECT, {
-          featureId: e.featureTarget.properties.parent,
-          coordPath: e.featureTarget.properties.coord_path,
-          startPos: e.lngLat
-        });
-        ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
-      });
-
-      // Mousedown on a selected feature
-      this.on('mousedown', CommonSelectors.isActiveFeature, function(e) {
-        // Stop any already-underway extended interactions
-        stopExtendedInteractions();
-
-        // Disable map.dragPan immediately so it can't start
-        ctx.map.dragPan.disable();
-
-        // Re-render it and enable drag move
-        this.render(e.featureTarget.properties.id);
-
-        // Set up the state for drag moving
-        canDragMove = true;
-        dragMoveLocation = e.lngLat;
-      });
-
-      // Click (with or without shift) on any feature
-      this.on('click', CommonSelectors.isFeature, function(e) {
-        // Stop everything
-        doubleClickZoom.disable(ctx);
-        stopExtendedInteractions();
-
-        const isShiftClick = CommonSelectors.isShiftDown(e);
-        const selectedFeatureIds = ctx.store.getSelectedIds();
-        const featureId = e.featureTarget.properties.id;
-        const isFeatureSelected = ctx.store.isSelected(featureId);
-
-        // Click (without shift) on any selected feature but a point
-        if (!isShiftClick && isFeatureSelected && ctx.store.get(featureId).type !== Constants.geojsonTypes.POINT) {
-          // Enter direct select mode
-          return ctx.events.changeMode(Constants.modes.DIRECT_SELECT, {
-            featureId: featureId
-          });
-        }
-
-        // Shift-click on a selected feature
-        if (isFeatureSelected && isShiftClick) {
-          // Deselect it
-          ctx.store.deselect(featureId);
-          ctx.ui.queueMapClasses({ mouse: Constants.cursors.POINTER });
-          if (selectedFeatureIds.length === 1 ) {
-            doubleClickZoom.enable(ctx);
-          }
-        // Shift-click on an unselected feature
-        } else if (!isFeatureSelected && isShiftClick) {
-          // Add it to the selection
-          ctx.store.select(featureId);
-          ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
-        // Click (without shift) on an unselected feature
-        } else if (!isFeatureSelected && !isShiftClick) {
-          // Make it the only selected feature
-          selectedFeatureIds.forEach(this.render);
-          ctx.store.setSelected(featureId);
-          ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
-        }
-
-        // No matter what, re-render the clicked feature
-        this.render(featureId);
-      });
-
-      // Dragging when drag move is enabled
-      this.on('drag', () => canDragMove, function(e) {
-        dragMoving = true;
-        e.originalEvent.stopPropagation();
-
-        const delta = {
-          lng: e.lngLat.lng - dragMoveLocation.lng,
-          lat: e.lngLat.lat - dragMoveLocation.lat
-        };
-
-        moveFeatures(ctx.store.getSelected(), delta);
-
-        dragMoveLocation = e.lngLat;
-      });
-
-      // Mouseup, always
-      this.on('mouseup', CommonSelectors.true, function(e) {
-        // End any extended interactions
-        if (dragMoving) {
-          ctx.map.fire(Constants.events.UPDATE, {
-            action: Constants.updateActions.MOVE,
-            features: ctx.store.getSelected().map(f => f.toGeoJSON())
-          });
-        } else if (boxSelecting) {
-          const bbox = [
-            boxSelectStartLocation,
-            mouseEventPoint(e.originalEvent, ctx.container)
-          ];
-          const featuresInBox = featuresAt(null, bbox, ctx);
-          const idsToSelect = getUniqueIds(featuresInBox)
-            .filter(id => !ctx.store.isSelected(id));
-
-          if (idsToSelect.length) {
-            ctx.store.select(idsToSelect);
-            idsToSelect.forEach(this.render);
-            ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
-          }
-        }
-        stopExtendedInteractions();
-      });
-
-      if (ctx.options.boxSelect) {
-        // Shift-mousedown anywhere
-        this.on('mousedown', CommonSelectors.isShiftMousedown, function(e) {
-          stopExtendedInteractions();
-          ctx.map.dragPan.disable();
-          // Enable box select
-          boxSelectStartLocation = mouseEventPoint(e.originalEvent, ctx.container);
-          canBoxSelect = true;
-        });
-
-        // Drag when box select is enabled
-        this.on('drag', () => canBoxSelect, function(e) {
-          boxSelecting = true;
-          ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
-
-          // Create the box node if it doesn't exist
-          if (!boxSelectElement) {
-            boxSelectElement = document.createElement('div');
-            boxSelectElement.classList.add(Constants.classes.BOX_SELECT);
-            ctx.container.appendChild(boxSelectElement);
-          }
-
-          // Adjust the box node's width and xy position
-          const current = mouseEventPoint(e.originalEvent, ctx.container);
-          const minX = Math.min(boxSelectStartLocation.x, current.x);
-          const maxX = Math.max(boxSelectStartLocation.x, current.x);
-          const minY = Math.min(boxSelectStartLocation.y, current.y);
-          const maxY = Math.max(boxSelectStartLocation.y, current.y);
-          const translateValue = `translate(${minX}px, ${minY}px)`;
-          boxSelectElement.style.transform = translateValue;
-          boxSelectElement.style.WebkitTransform = translateValue;
-          boxSelectElement.style.width = `${maxX - minX}px`;
-          boxSelectElement.style.height = `${maxY - minY}px`;
-        });
-      }
-    },
-    render: function(geojson, push) {
-      geojson.properties.active = (ctx.store.isSelected(geojson.properties.id) )
-        ? Constants.activeStates.ACTIVE
-        : Constants.activeStates.INACTIVE;
-      push(geojson);
-      if (geojson.properties.active !== Constants.activeStates.ACTIVE
-        || geojson.geometry.type === Constants.geojsonTypes.POINT) return;
-      createSupplementaryPoints(geojson).forEach(push);
-    },
-    trash() {
-      ctx.store.delete(ctx.store.getSelectedIds());
-    }
-  };
+  return ids.values();
 };
+
+export default class SimpleSelectMode extends ModeInterface {
+  constructor (options, store, ui) {
+    this.boxSelectIsOn = options.boxSelect;
+    this.dragMoveLocation = null;
+    this.boxSelectStartLocation = null;
+    this.boxSelectElement;
+    this.boxSelecting = false;
+    this.canBoxSelect = false;
+    this.dragMoving = false;
+    this.canDragMove = false;
+    this.initiallySelectedFeatureIds = options.featureIds || [];
+  }
+  stopExtendedInteractions() {
+    if (this.boxSelectElement) {
+      if (this.boxSelectElement.parentNode) this.boxSelectElement.parentNode.removeChild(this.boxSelectElement);
+      this.boxSelectElement = null;
+    }
+
+    this.dragPan(true);
+
+    this.boxSelecting = false;
+    this.canBoxSelect = false;
+    this.dragMoving = false;
+    this.canDragMove = false;
+  }
+
+  changeMode (nextModeName, store, ui) {
+    this.doubleClickZoom(true);
+  }
+
+  onMouseUp(e, store, ui) {
+    // Any mouseup should stop box selecting and dragMoving
+    this.stopExtendedInteractions();
+  }
+
+  // On mousemove that is not a drag, stop extended interactions.
+  // This is useful if you drag off the canvas, release the button,
+  // then move the mouse back over the canvas --- we don't the
+  // interaction to continue (but we do let it continue if you held
+  // the mouse button that whole time)
+  onMousemove(e, store, ui) {
+    this.stopExtendedInteractions();
+  }
+
+  onClick(e, store, ui) {
+    if (CommonSelectors.noTarget(e)) {
+      // Clear the re-render selection
+      const wasSelected = store.getSelectedIds();
+      if (wasSelected.length) {
+        store.clearSelected();
+        wasSelected.forEach(id => this.render(id));
+      }
+      this.doubleClickZoom(true);
+      return this.stopExtendedInteractions();
+    }
+
+    if (CommonSelectors.isVertex(e)) {
+      // how does this handle coords
+      store.setSelected([e.featureTarget.properties.parent], [e.featureTarget.properties.coord_path]);
+      this.changeMode(Constants.modes.DIRECT_SELECT);
+      ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
+    }
+  }
+
+  onMousedown(e, store, ui) {
+    // Mousedown on a selected feature
+    if (CommonSelectors.isActiveFeature(e)) {
+      // Stop any already-underway extended interactions
+      this.stopExtendedInteractions();
+
+     // Disable map.dragPan immediately so it can't start
+      this.dragPan(false);
+
+      // Re-render it and enable drag move
+      store.featureChanged(e.featureTarget.properties.id);
+
+      // Set up the state for drag moving
+      this.canDragMove = true;
+      this.dragMoveLocation = e.lngLat;
+      return;
+    }
+
+    if (CommonSelectors.isShiftMousedown(e) && this.boxSelectIsOn) {
+      this.stopExtendedInteractions();
+      this.dragPan(false);
+      // Enable box select
+      this.boxSelectStartLocation = e.mapPoint;
+      this.canBoxSelect = true;
+    }
+  }
+
+  onClick(e, store, ui) {
+    // Click (with or without shift) on any feature
+    if (CommonSelectors.isFeature(e)) {
+      // Stop everything
+      this.doubleClickZoom(false);
+      this.stopExtendedInteractions();
+
+      const isShiftClick = CommonSelectors.isShiftDown(e);
+      const selectedFeatureIds = store.getSelectedIds();
+      const featureId = e.featureTarget.properties.id;
+      const isFeatureSelected = store.isSelected(featureId);
+
+      // Click (without shift) on any selected feature but a point
+      if (!isShiftClick && isFeatureSelected && store.get(featureId).type !== Constants.geojsonTypes.POINT) {
+        // Enter direct select mode
+        store.setSelected([featureId]);
+        this.changeMode(Constants.modes.DIRECT_SELECT);
+      }
+
+      // Shift-click on a selected feature
+      if (isFeatureSelected && isShiftClick) {
+        // Deselect it
+        store.deselect(featureId);
+        ui.queueMapClasses({ mouse: Constants.cursors.POINTER });
+        if (selectedFeatureIds.length === 1 ) {
+          this.doubleClickZoom(true);
+        }
+      // Shift-click on an unselected feature
+      } else if (!isFeatureSelected && isShiftClick) {
+        // Add it to the selection
+        store.select(featureId);
+        ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
+      // Click (without shift) on an unselected feature
+      } else if (!isFeatureSelected && !isShiftClick) {
+        // Make it the only selected feature
+        selectedFeatureIds.forEach(this.render);
+        store.setSelected(featureId);
+        ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
+      }
+
+      // No matter what, re-render the clicked feature
+      store.featureChanged(featureId);
+    }
+  }
+
+  onDrag (e, store, ui) {
+    // Dragging when drag move is enabled
+    if (this.canDragMove) {
+      this.dragMoving = true;
+      e.originalEvent.stopPropagation();
+
+      const delta = {
+        lng: e.lngLat.lng - dragMoveLocation.lng,
+        lat: e.lngLat.lat - dragMoveLocation.lat
+      };
+
+      moveFeatures(store.getSelected(), delta);
+
+      this.dragMoveLocation = e.lngLat;
+    }
+
+    if (this.canBoxSelect === true && this.boxSelectIsOn) {
+      this.boxSelecting = true;
+      ui.queueMapClasses({ mouse: Constants.cursors.ADD });
+
+      // Create the box node if it doesn't exist
+      if (!this.boxSelectElement) {
+        this.boxSelectElement = document.createElement('div');
+        this.boxSelectElement.classList.add(Constants.classes.BOX_SELECT);
+        this.appendChild(boxSelectElement);
+      }
+
+      // Adjust the box node's width and xy position
+      const current = e.mousePoint;
+      const minX = Math.min(this.boxSelectStartLocation.x, current.x);
+      const maxX = Math.max(this.boxSelectStartLocation.x, current.x);
+      const minY = Math.min(this.boxSelectStartLocation.y, current.y);
+      const maxY = Math.max(this.boxSelectStartLocation.y, current.y);
+      const translateValue = `translate(${minX}px, ${minY}px)`;
+      this.boxSelectElement.style.transform = translateValue;
+      this.boxSelectElement.style.WebkitTransform = translateValue;
+      this.boxSelectElement.style.width = `${maxX - minX}px`;
+      this.boxSelectElement.style.height = `${maxY - minY}px`;
+    }
+
+  }
+
+  onMouseup(e, store, ui) {
+    if (this.dragMoving) {
+      this.fire(Constants.events.UPDATE, {
+        action: Constants.updateActions.MOVE,
+        features: store.getSelected().map(f => f.toGeoJSON())
+      });
+      return stopExtendedInteractions();
+    }
+
+    if (this.boxSelecting) {
+      const bbox = [
+        this.boxSelectStartLocation,
+        e.mousePoint
+      ];
+      const featuresInBox = store.featuresAt(bbox);
+      const idsToSelect = getUniqueIds(featuresInBox)
+        .filter(id => !store.isSelected(id));
+
+      if (idsToSelect.length) {
+        store.select(idsToSelect);
+        idsToSelect.forEach(this.render);
+        ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
+      }
+    }
+    return stopExtendedInteractions();
+  }
+
+  prepareAndRender(geojson, render, store) {
+    geojson.properties.active = (store.isSelected(geojson.properties.id) )
+      ? Constants.activeStates.ACTIVE
+      : Constants.activeStates.INACTIVE;
+    render(geojson);
+    if (geojson.properties.active !== Constants.activeStates.ACTIVE
+      || geojson.geometry.type === Constants.geojsonTypes.POINT) return;
+    createSupplementaryPoints(geojson).forEach(render);
+  }
+
+  onTrash(store) {
+    store.delete(store.getSelectedIds());
+  }
+}

--- a/src/modes/static.js
+++ b/src/modes/static.js
@@ -1,9 +1,7 @@
-module.exports = function() {
-  return {
-    stop: function() {},
-    start: function() {},
-    render: function(geojson, push) {
-      push(geojson);
-    }
-  };
-};
+import ModeInterface from './mode_interface';
+
+export default class StaticMode extends ModeInterface {
+  prepareAndRender(geojson, render) {
+    render(geojson);
+  }
+}

--- a/src/store.js
+++ b/src/store.js
@@ -90,6 +90,9 @@ Store.prototype.getAllIds = function() {
  * @return {Store} this
  */
 Store.prototype.add = function(feature) {
+  feature.changed = () => {
+    this.featureChanged(feature.id);
+  }
   this.featureChanged(feature.id);
   this._features[feature.id] = feature;
   this._featureIds.add(feature.id);

--- a/src/store.js
+++ b/src/store.js
@@ -2,6 +2,7 @@ var throttle = require('./lib/throttle');
 var toDenseArray = require('./lib/to_dense_array');
 var StringSet = require('./lib/string_set');
 var render = require('./render');
+const featuresAt = require('./lib/features_at');
 
 var Store = module.exports = function(ctx) {
   this._features = {};
@@ -19,6 +20,10 @@ var Store = module.exports = function(ctx) {
   this.isDirty = false;
 };
 
+
+Store.prototype.featuresAt = function(bbox) {
+  return featuresAt(null, bbox, this.ctx);
+}
 
 /**
  * Delays all rendering until the returned function is invoked


### PR DESCRIPTION
@kiRach and @davidtheclark 

After @davidtheclark's and my conversations about cleaning up modes and @kiRach observations of how verbose new modes can be I think we should move to make modes into classes. This will let them be extended (so you can make slightly different modes without much work) and will standardize how the mode interfaces with the rest of Draw a bit better.

This PR is just a POC. It does not work at all.
