### PR TITLE
Prevent deleted features emitting twice

### DIFF
--- a/src/lib/throttle.js
+++ b/src/lib/throttle.js
@@ -16,10 +16,10 @@ function throttle(fn, time, context) {
       args = arguments;
 
     } else {
-      // call and lock until later
+      // lock until later then call
+      lock = true;
       fn.apply(context, arguments);
       setTimeout(later, time);
-      lock = true;
     }
   };
 

--- a/src/render.js
+++ b/src/render.js
@@ -61,10 +61,13 @@ module.exports = function render() {
   }
 
   if (store._deletedFeaturesToEmit.length) {
-    store.ctx.map.fire(Constants.events.DELETE, {
-      features: store._deletedFeaturesToEmit.map(feature => feature.toGeoJSON())
-    });
+    var geojsonToEmit = store._deletedFeaturesToEmit.map(feature => feature.toGeoJSON());
+
     store._deletedFeaturesToEmit = [];
+
+    store.ctx.map.fire(Constants.events.DELETE, {
+      features: geojsonToEmit
+    });
   }
 
   store.ctx.map.fire(Constants.events.RENDER, {});


### PR DESCRIPTION
We ran into a bug in which the `draw.delete` event was firing twice before the next line of code, which clears the array of features to emit, was cleared. So we ended up with listeners thinking the same feature was deleted twice.

My guess as to why this was happening is because the firing of the event sent us down a completely synchronous code path that ended up looping us back to that very spot where the event fired. Then the event fired again before we got to that next line that clears the array. Solution, then, is to clear the array before firing the event.

cc @mcwhittemore 