### PR TITLE
Use function expression instead of function declaration

### DIFF
--- a/src/lib/sort_features.js
+++ b/src/lib/sort_features.js
@@ -7,7 +7,7 @@ const FEATURE_SORT_RANKS = {
   Polygon: 2
 };
 
-function comparator(a, b) {
+const comparator = (a, b) => {
   const score = FEATURE_SORT_RANKS[a.geometry.type] - FEATURE_SORT_RANKS[b.geometry.type];
 
   if (score === 0 && a.geometry.type === Constants.geojsonTypes.POLYGON) {

--- a/src/options.js
+++ b/src/options.js
@@ -26,7 +26,7 @@ const hideControls = {
   trash: false
 };
 
-function addSources(styles, sourceBucket) {
+const addSources = (styles, sourceBucket) => {
   return styles.map(style => {
     if (style.source) return style;
     return xtend(style, {
@@ -36,7 +36,7 @@ function addSources(styles, sourceBucket) {
         : Constants.sources.COLD
     });
   });
-}
+};
 
 module.exports = function(options = {}) {
   let withDefaults = xtend(options);


### PR DESCRIPTION
This fixes a scoping issue with these functions when using Webpack. These two functions are undefined at runtime when they are defined using function declarations. It works fine when defined using function expressions. I can't figure out why this is happening, but it won't hurt to merge this change.