### PR TITLE
Fire draw.update on mouseout when dragging

### DIFF
--- a/API.md
+++ b/API.md
@@ -314,7 +314,7 @@ Fired when one or more features are updated. The following will trigger this eve
 - `action: 'move'`
   - Finish moving one or more selected features in `simple_select` mode. The event will only fire when the movement is finished — i.e. when the user releases the mouse button or hits Enter.
 - `action: 'change_coordinates'`
-  - Finish moving one or more vertices of a selected feature in `direct_select` mode. The event will only fire when the movement is finished — i.e. when the user releases the mouse button or hits Enter.
+  - Finish moving one or more vertices of a selected feature in `direct_select` mode. The event will only fire when the movement is finished — i.e. when the user releases the mouse button or hits Enter, or her mouse leaves the map container.
   - Delete one or more vertices of a selected feature in `direct_select` mode, which can be done by hitting the Backspace or Delete keys, clicking the Trash button, or invoking `Draw.trash()`.
   - Add a vertex to the selected feature by clicking a midpoint on that feature in `direct_select` mode.
 

--- a/src/events.js
+++ b/src/events.js
@@ -66,6 +66,10 @@ module.exports = function(ctx) {
     }
   };
 
+  events.mouseout = function(event) {
+    currentMode.mouseout(event);
+  };
+
   // 8 - Backspace
   // 46 - Delete
   var isKeyModeValid = (code) => !(code === 8 || code === 46 || (code >= 48 && code <= 57));
@@ -137,6 +141,8 @@ module.exports = function(ctx) {
       ctx.map.on('mousedown', events.mousedown);
       ctx.map.on('mouseup', events.mouseup);
 
+      ctx.container.addEventListener('mouseout', events.mouseout);
+
       if (ctx.options.keybindings) {
         ctx.container.addEventListener('keydown', events.keydown);
         ctx.container.addEventListener('keyup', events.keyup);
@@ -147,6 +153,8 @@ module.exports = function(ctx) {
 
       ctx.map.off('mousedown', events.mousedown);
       ctx.map.off('mouseup', events.mouseup);
+
+      ctx.container.removeEventListener('mouseout', events.mouseout);
 
       if (ctx.options.keybindings) {
         ctx.container.removeEventListener('keydown', events.keydown);

--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -6,6 +6,7 @@ var ModeHandler = function(mode, DrawContext) {
     mousemove: [],
     mousedown: [],
     mouseup: [],
+    mouseout: [],
     keydown: [],
     keyup: []
   };
@@ -70,6 +71,9 @@ var ModeHandler = function(mode, DrawContext) {
     },
     mouseup: function(event) {
       delegate('mouseup', event);
+    },
+    mouseout: function(event) {
+      delegate('mouseout', event);
     },
     keydown: function(event) {
       delegate('keydown', event);

--- a/test/direct_select.test.js
+++ b/test/direct_select.test.js
@@ -8,10 +8,13 @@ import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by 
 import AfterNextRender from './utils/after_next_render';
 import makeMouseEvent from './utils/make_mouse_event';
 import Constants from '../src/constants';
+import createSyntheticEvent from 'synthetic-dom-events';
 
 test('direct_select', t => {
 
-  const map = createMap();
+  const mapContainer = document.createElement('div');
+  document.body.appendChild(mapContainer);
+  const map = createMap({ container: mapContainer });
   spy(map, 'fire');
 
   const Draw = GLDraw();
@@ -27,10 +30,18 @@ test('direct_select', t => {
     }
   };
 
-  t.test('direct_select - init map for tests', t => {
+  const getFireArgs = function() {
+    const args = [];
+    for (let i = 0; i < map.fire.callCount; i++) {
+      args.push(map.fire.getCall(i).args);
+    }
+    return args;
+  };
+
+  t.test('direct_select - init map for tests', st => {
     const done = function() {
       map.off('load', done);
-      t.end();
+      st.end();
     };
     if (map.loaded()) {
       done();
@@ -40,7 +51,7 @@ test('direct_select', t => {
     }
   });
 
-  t.test('direct_select - a click on a vertex and than dragging the map shouldn\'t drag the vertex', t => {
+  t.test('direct_select - a click on a vertex and than dragging the map shouldn\'t drag the vertex', st => {
     var ids = Draw.add(getGeoJSON('polygon'));
     Draw.changeMode(Constants.modes.DIRECT_SELECT, {
       featureId: ids[0]
@@ -54,9 +65,68 @@ test('direct_select', t => {
         map.fire('mousemove', makeMouseEvent(clickAt[0] + 30, clickAt[1] + 30, { which: 1 }));
         map.fire('mouseup', makeMouseEvent(clickAt[0] + 30, clickAt[1] + 30));
         var afterMove = Draw.get(ids[0]);
-        t.deepEquals(getGeoJSON('polygon').geometry, afterMove.geometry, 'should be the same after the drag');
-        cleanUp(() => t.end());
+        st.deepEquals(getGeoJSON('polygon').geometry, afterMove.geometry, 'should be the same after the drag');
+        cleanUp(() => st.end());
       });
     });
   });
+
+  t.test('direct_select - fire one update when dragging mouse leaves container and button is released outside', st => {
+    var ids = Draw.add(getGeoJSON('polygon'));
+    Draw.changeMode(Constants.modes.DIRECT_SELECT, {
+      featureId: ids[0]
+    });
+
+    var startPosition = getGeoJSON('polygon').geometry.coordinates[0][1];
+    afterNextRender(() => {
+      click(map, makeMouseEvent(startPosition[0], startPosition[1]));
+      afterNextRender(() => {
+        map.fire.reset();
+        map.fire('mousedown', makeMouseEvent(startPosition[0], startPosition[1]));
+        map.fire('mousemove', makeMouseEvent(startPosition[0] + 15, startPosition[1] + 15, { which: 1 }));
+        mapContainer.dispatchEvent(createSyntheticEvent('mouseout'));
+        map.fire('mousemove', makeMouseEvent(startPosition[0] + 30, startPosition[1] + 30));
+        map.fire('mouseup', makeMouseEvent(startPosition[0] + 30, startPosition[1] + 30));
+
+        var afterMove = Draw.get(ids[0]);
+        var args = getFireArgs().filter(arg => arg[0] === 'draw.update');
+        st.equal(args.length, 1, 'draw.update called once');
+        st.equal(afterMove.geometry.coordinates[0][1][0], startPosition[0] + 15, 'point lng moved only the first amount');
+        st.equal(afterMove.geometry.coordinates[0][1][1], startPosition[1] + 15, 'point lat moved only the first amount');
+
+        cleanUp(() => st.end());
+      });
+    });
+  });
+
+  t.test('direct_select - fire two updates when dragging mouse leaves container then returns and button is released inside', st => {
+    var ids = Draw.add(getGeoJSON('polygon'));
+    Draw.changeMode(Constants.modes.DIRECT_SELECT, {
+      featureId: ids[0]
+    });
+
+    var startPosition = getGeoJSON('polygon').geometry.coordinates[0][1];
+    afterNextRender(() => {
+      click(map, makeMouseEvent(startPosition[0], startPosition[1]));
+      afterNextRender(() => {
+        map.fire.reset();
+        map.fire('mousedown', makeMouseEvent(startPosition[0], startPosition[1]));
+        map.fire('mousemove', makeMouseEvent(startPosition[0] + 15, startPosition[1] + 15, { which: 1 }));
+        mapContainer.dispatchEvent(createSyntheticEvent('mouseout'));
+        map.fire('mousemove', makeMouseEvent(startPosition[0] + 30, startPosition[1] + 30, { which: 1 }));
+        map.fire('mouseup', makeMouseEvent(startPosition[0] + 30, startPosition[1] + 30));
+
+        var afterMove = Draw.get(ids[0]);
+        var args = getFireArgs().filter(arg => arg[0] === 'draw.update');
+        st.equal(args.length, 2, 'draw.update called twice');
+        st.equal(afterMove.geometry.coordinates[0][1][0], startPosition[0] + 30, 'point lng moved to the mouseup location');
+        st.equal(afterMove.geometry.coordinates[0][1][1], startPosition[1] + 30, 'point lat moved to the mouseup location');
+
+        cleanUp(() => st.end());
+      });
+    });
+  });
+
+  document.body.removeChild(mapContainer);
+  t.end();
 });

--- a/test/mode_handler.test.js
+++ b/test/mode_handler.test.js
@@ -15,9 +15,10 @@ test('returned API', t => {
   t.equal(typeof mh.mousemove, 'function', 'exposes mousemove');
   t.equal(typeof mh.mousedown, 'function', 'exposes mousedown');
   t.equal(typeof mh.mouseup, 'function', 'exposes mouseup');
+  t.equal(typeof mh.mouseout, 'function', 'exposes mouseout');
   t.equal(typeof mh.keydown, 'function', 'exposes keydown');
   t.equal(typeof mh.keyup, 'function', 'exposes keyup');
-  t.equal(Object.keys(mh).length, 10, 'no unexpected properties');
+  t.equal(Object.keys(mh).length, 11, 'no unexpected properties');
   t.end();
 });
 
@@ -88,6 +89,12 @@ test('ModeHandler calling mode.start with context, and delegation functionality'
   mh.mouseup({ two: 2 });
   t.equal(mouseupSpy.callCount, 1, 'mouseup callback called via delegation');
   t.deepEqual(mouseupSpy.getCall(0).args, [{ two: 2 }], 'with correct argument');
+
+  const mouseoutSpy = spy();
+  startContext.on('mouseout', () => true, mouseoutSpy);
+  mh.mouseout({ two: 2 });
+  t.equal(mouseoutSpy.callCount, 1, 'mouseout callback called via delegation');
+  t.deepEqual(mouseoutSpy.getCall(0).args, [{ two: 2 }], 'with correct argument');
 
   const keydownSpy = spy();
   startContext.on('keydown', () => true, keydownSpy);

--- a/test/utils/make_mouse_event.js
+++ b/test/utils/make_mouse_event.js
@@ -1,6 +1,6 @@
 const xtend = require('xtend');
 
-module.exports = function(lng, lat, eventProperties = {}) {
+module.exports = function(lng = 0, lat = 0, eventProperties = {}) {
   var e = {
     originalEvent: xtend({
       stopPropagation: function() {},


### PR DESCRIPTION
This PR introduces `mouseout` events and causes a `draw.update` event to fire if you've been dragging a feature or vertex and your mouse leaves the container.

Before this, we had a problem that you could drag-move something until your mouse leaves the container, release the mouse button outside, then return, and the feature would have changed its position but no` draw.update` event would have been fired. With these changes, a `draw.update` will be fired anytime you leave. (If you continue to hold the mouse button down and move back in, continuing the drag, then mouseup, ending the drag, you'll get another `draw.update` event.)

@mcwhittemore for review.

