### PR TITLE
Update API docs regarding style ids and sources

### DIFF
--- a/API.md
+++ b/API.md
@@ -41,6 +41,8 @@ Lets you select, delete and drag features.
 
 In this mode, features can have their active state changed by the user. To control what is active, react to changes as described in the events section below.
 
+Draw will transition into `simple_select` mode every time a single feature has completed drawing.
+
 ### `direct_select`
 
 `Draw.modes.DIRECT_SELECT === 'direct_select'`
@@ -382,13 +384,19 @@ Fired just after Draw calls `setData()` on `mapbox-gl-js`. This does not imply t
 
 Draw is styled by the [Mapbox GL Style Spec](https://www.mapbox.com/mapbox-gl-style-spec/) with a preset list of properties.
 
+`source`
+
 The `GL Style Spec` requires each layer to have a source. **DO NOT PROVIDE THIS** for styling draw.
 
-The `GL Style Spec` also requires an id. Draw will provide this for you. If you wish to set this id to interact with draw layers, know that Draw will add `hot` and `cold` if no source is provided.
-
-Draw moves features between sources for performance gains, because of this it is recommeneded that you **DO NOT** provide a source for a style despite the fact the `GL Style Spec` requires a source. **Draw will provide the source for you automatically**.
+Draw moves features between sources for performance gains, because of this it is recommended that you **DO NOT** provide a source for a style despite the fact the `GL Style Spec` requires a source. **Draw will provide the source for you automatically**.
 
 If you need to style gl-draw for debugging sources the source names are `mapbox-gl-draw-hot` and `mapbox-gl-draw-cold`.
+
+`id`
+
+The `GL Style Spec` also requires an id. **YOU MUST PROVIDE THIS**.
+
+Draw will add `.hot` and `.cold` to the end of your id.
 
 property | values | function
 --- | --- | ---
@@ -398,11 +406,12 @@ mode |  simple_select, direct_select, draw_point, draw_line_string, draw_polygon
 
 Draw also provides a few more properties, but they should not be used for styling. For details on them, see `Using Draw with map.queryRenderFeatures`.
 
-### Example Custom Style
-
-With this style all Point features are blue and have a black halo when active. No other features are rendered, even if they are present.
+### Example Custom Styles
 
 ```js
+// With this style, all Point features are blue and have a black halo when active.
+// No other features are rendered, even if they are present.
+
 mapbox.Draw({
   styles: [
     {
@@ -433,6 +442,126 @@ mapbox.Draw({
     }
   ]
 });
+
+// With this style, all line and polygon features are have dashed red outline
+// and transparent fill while being drawn, including the point vertices.
+// When the Draw mode is changed the 'static', these features will be drawn
+// with solid black outline and transparent fill.
+// Point vertices use the same point filter, and render these points twice:
+// once as a larger-radius halo, and again as the vertex inset point.
+
+// ACTIVE (being drawn)
+// line stroke
+{
+    "id": "gl-draw-line",
+    "type": "line",
+    "filter": ["all", ["==", "$type", "LineString"], ["!=", "mode", "static"]],
+    "layout": {
+      "line-cap": "round",
+      "line-join": "round"
+    },
+    "paint": {
+      "line-color": "#D20C0C",
+      "line-dasharray": [0.2, 2],
+      "line-width": 2
+    },
+    "interactive": true
+},
+// polygon fill
+{
+  "id": "gl-draw-polygon-fill",
+  "type": "fill",
+  "filter": ["all", ["==", "$type", "Polygon"], ["!=", "mode", "static"]],
+  "paint": {
+    "fill-color": "#D20C0C",
+    "fill-outline-color": "#D20C0C",
+    "fill-opacity": 0.1
+  },
+  "interactive": true
+},
+// polygon outline stroke
+// This doesn't style the first edge of the polygon, which uses the line stroke styling instead
+{
+  "id": "gl-draw-polygon-stroke-active",
+  "type": "line",
+  "filter": ["all", ["==", "$type", "Polygon"], ["!=", "mode", "static"]],
+  "layout": {
+    "line-cap": "round",
+    "line-join": "round"
+  },
+  "paint": {
+    "line-color": "#D20C0C",
+    "line-dasharray": [0.2, 2],
+    "line-width": 2
+  },
+  "interactive": true
+},
+// vertex point halos
+{
+  "id": "gl-draw-polygon-and-line-vertex-halo-active",
+  "type": "circle",
+  "filter": ["all", ["==", "meta", "vertex"], ["==", "$type", "Point"], ["!=", "mode", "static"]],
+  "paint": {
+    "circle-radius": 5,
+    "circle-color": "#FFF"
+  },
+  "interactive": true
+},
+// vertex points
+{
+  "id": "gl-draw-polygon-and-line-vertex-active",
+  "type": "circle",
+  "filter": ["all", ["==", "meta", "vertex"], ["==", "$type", "Point"], ["!=", "mode", "static"]],
+  "paint": {
+    "circle-radius": 3,
+    "circle-color": "#D20C0C",
+  },
+  "interactive": true
+},
+
+// INACTIVE (static, already drawn)
+// line stroke
+{
+    "id": "gl-draw-line-static",
+    "type": "line",
+    "filter": ["all", ["==", "$type", "LineString"], ["==", "mode", "static"]],
+    "layout": {
+      "line-cap": "round",
+      "line-join": "round"
+    },
+    "paint": {
+      "line-color": "#000",
+      "line-width": 3
+    },
+    "interactive": true
+},
+// polygon fill
+{
+  "id": "gl-draw-polygon-fill-static",
+  "type": "fill",
+  "filter": ["all", ["==", "$type", "Polygon"], ["==", "mode", "static"]],
+  "paint": {
+    "fill-color": "#000",
+    "fill-outline-color": "#000",
+    "fill-opacity": 0.1
+  },
+  "interactive": true
+},
+// polygon outline
+{
+  "id": "gl-draw-polygon-stroke-static",
+  "type": "line",
+  "filter": ["all", ["==", "$type", "Polygon"], ["==", "mode", "static"]],
+  "layout": {
+    "line-cap": "round",
+    "line-join": "round"
+  },
+  "paint": {
+    "line-color": "#000",
+    "line-width": 3
+  },
+  "interactive": true
+}
 ```
 
 ## Using Draw with `map.queryRenderFeatures`

--- a/API.md
+++ b/API.md
@@ -384,7 +384,7 @@ Fired just after Draw calls `setData()` on `mapbox-gl-js`. This does not imply t
 
 Draw is styled by the [Mapbox GL Style Spec](https://www.mapbox.com/mapbox-gl-style-spec/) with a preset list of properties.
 
-`source`
+**source**
 
 The `GL Style Spec` requires each layer to have a source. **DO NOT PROVIDE THIS** for styling draw.
 
@@ -392,7 +392,7 @@ Draw moves features between sources for performance gains, because of this it is
 
 If you need to style gl-draw for debugging sources the source names are `mapbox-gl-draw-hot` and `mapbox-gl-draw-cold`.
 
-`id`
+**id**
 
 The `GL Style Spec` also requires an id. **YOU MUST PROVIDE THIS**.
 
@@ -408,161 +408,7 @@ Draw also provides a few more properties, but they should not be used for stylin
 
 ### Example Custom Styles
 
-```js
-// With this style, all Point features are blue and have a black halo when active.
-// No other features are rendered, even if they are present.
-
-mapbox.Draw({
-  styles: [
-    {
-      'id': 'highlight-active-points',
-      'type': 'circle',
-      'filter': ['all',
-        ['==', '$type', 'Point'],
-        ['==', 'meta', 'feature'],
-        ['==', 'active', 'true']],
-      'paint': {
-        'circle-radius': 7,
-        'circle-color': '#000000'
-      },
-      'interactive': true
-    },
-    {
-      'id': 'points-are-blue',
-      'type': 'circle',
-      'filter': ['all',
-        ['==', '$type', 'Point'],
-        ['==', 'meta', 'feature'],
-        ['==', 'active', 'true']],
-      'paint': {
-        'circle-radius': 5,
-        'circle-color': '#000088'
-      },
-      'interactive': true
-    }
-  ]
-});
-
-// With this style, all line and polygon features are have dashed red outline
-// and transparent fill while being drawn, including the point vertices.
-// When the Draw mode is changed the 'static', these features will be drawn
-// with solid black outline and transparent fill.
-// Point vertices use the same point filter, and render these points twice:
-// once as a larger-radius halo, and again as the vertex inset point.
-
-// ACTIVE (being drawn)
-// line stroke
-{
-    "id": "gl-draw-line",
-    "type": "line",
-    "filter": ["all", ["==", "$type", "LineString"], ["!=", "mode", "static"]],
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "paint": {
-      "line-color": "#D20C0C",
-      "line-dasharray": [0.2, 2],
-      "line-width": 2
-    },
-    "interactive": true
-},
-// polygon fill
-{
-  "id": "gl-draw-polygon-fill",
-  "type": "fill",
-  "filter": ["all", ["==", "$type", "Polygon"], ["!=", "mode", "static"]],
-  "paint": {
-    "fill-color": "#D20C0C",
-    "fill-outline-color": "#D20C0C",
-    "fill-opacity": 0.1
-  },
-  "interactive": true
-},
-// polygon outline stroke
-// This doesn't style the first edge of the polygon, which uses the line stroke styling instead
-{
-  "id": "gl-draw-polygon-stroke-active",
-  "type": "line",
-  "filter": ["all", ["==", "$type", "Polygon"], ["!=", "mode", "static"]],
-  "layout": {
-    "line-cap": "round",
-    "line-join": "round"
-  },
-  "paint": {
-    "line-color": "#D20C0C",
-    "line-dasharray": [0.2, 2],
-    "line-width": 2
-  },
-  "interactive": true
-},
-// vertex point halos
-{
-  "id": "gl-draw-polygon-and-line-vertex-halo-active",
-  "type": "circle",
-  "filter": ["all", ["==", "meta", "vertex"], ["==", "$type", "Point"], ["!=", "mode", "static"]],
-  "paint": {
-    "circle-radius": 5,
-    "circle-color": "#FFF"
-  },
-  "interactive": true
-},
-// vertex points
-{
-  "id": "gl-draw-polygon-and-line-vertex-active",
-  "type": "circle",
-  "filter": ["all", ["==", "meta", "vertex"], ["==", "$type", "Point"], ["!=", "mode", "static"]],
-  "paint": {
-    "circle-radius": 3,
-    "circle-color": "#D20C0C",
-  },
-  "interactive": true
-},
-
-// INACTIVE (static, already drawn)
-// line stroke
-{
-    "id": "gl-draw-line-static",
-    "type": "line",
-    "filter": ["all", ["==", "$type", "LineString"], ["==", "mode", "static"]],
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "paint": {
-      "line-color": "#000",
-      "line-width": 3
-    },
-    "interactive": true
-},
-// polygon fill
-{
-  "id": "gl-draw-polygon-fill-static",
-  "type": "fill",
-  "filter": ["all", ["==", "$type", "Polygon"], ["==", "mode", "static"]],
-  "paint": {
-    "fill-color": "#000",
-    "fill-outline-color": "#000",
-    "fill-opacity": 0.1
-  },
-  "interactive": true
-},
-// polygon outline
-{
-  "id": "gl-draw-polygon-stroke-static",
-  "type": "line",
-  "filter": ["all", ["==", "$type", "Polygon"], ["==", "mode", "static"]],
-  "layout": {
-    "line-cap": "round",
-    "line-join": "round"
-  },
-  "paint": {
-    "line-color": "#000",
-    "line-width": 3
-  },
-  "interactive": true
-}
-```
+See [EXAMPLES.md](https://github.com/mapbox/mapbox-gl-draw/blob/master/EXAMPLES.md) for examples of custom styles.reference.
 
 ## Using Draw with `map.queryRenderFeatures`
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,166 @@
+# Examples
+
+## Styling
+
+See [API.md](https://github.com/mapbox/mapbox-gl-draw/blob/master/API.md) for a complete styling reference.
+
+### points
+
+With this style, all Point features are blue and have a black halo when active.
+No other features are rendered, even if they are present.
+
+```js
+mapbox.Draw({
+  styles: [
+    {
+      'id': 'highlight-active-points',
+      'type': 'circle',
+      'filter': ['all',
+        ['==', '$type', 'Point'],
+        ['==', 'meta', 'feature'],
+        ['==', 'active', 'true']],
+      'paint': {
+        'circle-radius': 7,
+        'circle-color': '#000000'
+      },
+      'interactive': true
+    },
+    {
+      'id': 'points-are-blue',
+      'type': 'circle',
+      'filter': ['all',
+        ['==', '$type', 'Point'],
+        ['==', 'meta', 'feature'],
+        ['==', 'active', 'true']],
+      'paint': {
+        'circle-radius': 5,
+        'circle-color': '#000088'
+      },
+      'interactive': true
+    }
+  ]
+});
+```
+
+### lines and polygons
+
+With this style, all line and polygon features are have dashed red outline and transparent fill while being drawn, including the point vertices. When the Draw mode is changed the 'static', these features will be drawn with solid black outline and transparent fill. Point vertices use the same point filter, and render these points twice: once as a larger-radius halo, and again as the vertex inset point.
+
+```js
+mapbox.Draw({
+  styles: [
+    // ACTIVE (being drawn)
+    // line stroke
+    {
+        "id": "gl-draw-line",
+        "type": "line",
+        "filter": ["all", ["==", "$type", "LineString"], ["!=", "mode", "static"]],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "#D20C0C",
+          "line-dasharray": [0.2, 2],
+          "line-width": 2
+        },
+        "interactive": true
+    },
+    // polygon fill
+    {
+      "id": "gl-draw-polygon-fill",
+      "type": "fill",
+      "filter": ["all", ["==", "$type", "Polygon"], ["!=", "mode", "static"]],
+      "paint": {
+        "fill-color": "#D20C0C",
+        "fill-outline-color": "#D20C0C",
+        "fill-opacity": 0.1
+      },
+      "interactive": true
+    },
+    // polygon outline stroke
+    // This doesn't style the first edge of the polygon, which uses the line stroke styling instead
+    {
+      "id": "gl-draw-polygon-stroke-active",
+      "type": "line",
+      "filter": ["all", ["==", "$type", "Polygon"], ["!=", "mode", "static"]],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#D20C0C",
+        "line-dasharray": [0.2, 2],
+        "line-width": 2
+      },
+      "interactive": true
+    },
+    // vertex point halos
+    {
+      "id": "gl-draw-polygon-and-line-vertex-halo-active",
+      "type": "circle",
+      "filter": ["all", ["==", "meta", "vertex"], ["==", "$type", "Point"], ["!=", "mode", "static"]],
+      "paint": {
+        "circle-radius": 5,
+        "circle-color": "#FFF"
+      },
+      "interactive": true
+    },
+    // vertex points
+    {
+      "id": "gl-draw-polygon-and-line-vertex-active",
+      "type": "circle",
+      "filter": ["all", ["==", "meta", "vertex"], ["==", "$type", "Point"], ["!=", "mode", "static"]],
+      "paint": {
+        "circle-radius": 3,
+        "circle-color": "#D20C0C",
+      },
+      "interactive": true
+    },
+
+    // INACTIVE (static, already drawn)
+    // line stroke
+    {
+        "id": "gl-draw-line-static",
+        "type": "line",
+        "filter": ["all", ["==", "$type", "LineString"], ["==", "mode", "static"]],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "#000",
+          "line-width": 3
+        },
+        "interactive": true
+    },
+    // polygon fill
+    {
+      "id": "gl-draw-polygon-fill-static",
+      "type": "fill",
+      "filter": ["all", ["==", "$type", "Polygon"], ["==", "mode", "static"]],
+      "paint": {
+        "fill-color": "#000",
+        "fill-outline-color": "#000",
+        "fill-opacity": 0.1
+      },
+      "interactive": true
+    },
+    // polygon outline
+    {
+      "id": "gl-draw-polygon-stroke-static",
+      "type": "line",
+      "filter": ["all", ["==", "$type", "Polygon"], ["==", "mode", "static"]],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#000",
+        "line-width": 3
+      },
+      "interactive": true
+    }
+  ]
+});
+```


### PR DESCRIPTION
This PR enhances the `API.md` docs to head off confusion for users who are learning to style `mapbox-gl-draw` features, as in this issue: https://github.com/mapbox/mapbox-gl-draw/issues/472

The must-have changes are the clarification of `source` and `id` here: https://github.com/mapbox/mapbox-gl-draw/compare/master...timiyay:feature/api-docs?expand=1#diff-88333ba11114e014e87198d04680144dR395

There's a few optional changes too:

* a second styling example - it's long example for styling for lines and polygons, which compliments the existing point-only example
* extra info on mode transitions, explaining how completed features always transition to `simple_select` (see https://github.com/mapbox/mapbox-gl-draw/issues/472#issuecomment-238578275)

I wasn't 100% on the vocabulary to use when explaining "completed" features. I was attempting to describe a feature that was in the process of being drawn by the user, who then double-clicked to "complete" the feature, and triggered the mode transition.

I also mimicked the use of **BOLD CAPITALISED** statements used in style source. These are arguably overkill, and I'd be happy to change them.