### PR TITLE
Fix geojsonhint error filter

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -50,7 +50,7 @@ module.exports = function(ctx) {
 
   api.add = function (geojson) {
     var featureCollection = normalize(geojson);
-    var errors = geojsonhint.hint(featureCollection).filter(e => e.level !== 'warn');
+    var errors = geojsonhint.hint(featureCollection).filter(e => e.level === 'error');
     if (errors.length) {
       throw new Error(errors[0].message);
     }


### PR DESCRIPTION
The latest version of geojsonhint uses `level: "message"` instead of `level: "warn"` — so I just switched this to a positive check for `level: "error"`.

@mcwhittemore for review. If you think this is good, let's release so we can take advantage downstream.