### PR TITLE
featuresAt returns unique features only

### DIFF
--- a/src/lib/features_at.js
+++ b/src/lib/features_at.js
@@ -1,6 +1,7 @@
 var sortFeatures = require('./sort_features');
 var mapEventToBoundingBox = require('./map_event_to_bounding_box');
 var Constants = require('../constants');
+var StringSet = require('./string_set');
 
 var META_TYPES = [
   Constants.meta.FEATURE,
@@ -24,5 +25,14 @@ module.exports = function(event, bbox, ctx) {
       return META_TYPES.indexOf(feature.properties.meta) !== -1;
     });
 
-  return sortFeatures(features);
+  var featureIds = new StringSet();
+  var uniqueFeatures = [];
+  features.forEach((feature) => {
+    const featureId = feature.properties.id;
+    if (featureIds.has(featureId)) return;
+    featureIds.add(featureId);
+    uniqueFeatures.push(feature);
+  });
+
+  return sortFeatures(uniqueFeatures);
 };

--- a/test/direct_select.test.js
+++ b/test/direct_select.test.js
@@ -85,7 +85,7 @@ test('direct_select', t => {
         map.fire('mousedown', makeMouseEvent(startPosition[0], startPosition[1]));
         map.fire('mousemove', makeMouseEvent(startPosition[0] + 15, startPosition[1] + 15, { which: 1 }));
         mapContainer.dispatchEvent(createSyntheticEvent('mouseout'));
-        map.fire('mousemove', makeMouseEvent(startPosition[0] + 30, startPosition[1] + 30));
+        map.fire('mousemove', makeMouseEvent(startPosition[0] + 30, startPosition[1] + 30), { which: 1 });
         map.fire('mouseup', makeMouseEvent(startPosition[0] + 30, startPosition[1] + 30));
 
         var afterMove = Draw.get(ids[0]);

--- a/test/features_at.test.js
+++ b/test/features_at.test.js
@@ -8,7 +8,8 @@ const mockContext = {
     queryRenderedFeatures: stub().returns([{
       type: 'Feature',
       properties: {
-        meta: 'feature'
+        meta: 'feature',
+        id: 'foo'
       },
       geometry: {
         type: 'LineString',
@@ -17,7 +18,8 @@ const mockContext = {
     }, {
       type: 'Feature',
       properties: {
-        meta: 'nothing'
+        meta: 'nothing',
+        id: 'bar'
       },
       geometry: {
         type: 'Polygon',
@@ -26,7 +28,18 @@ const mockContext = {
     }, {
       type: 'Feature',
       properties: {
-        meta: 'vertex'
+        meta: 'vertex',
+        id: 'baz'
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [10, 10]
+      }
+    }, {
+      type: 'Feature',
+      properties: {
+        meta: 'vertex',
+        id: 'baz'
       },
       geometry: {
         type: 'Point',
@@ -47,7 +60,8 @@ test('featuresAt with bounding box', t => {
   t.deepEqual(result, [{
     type: 'Feature',
     properties: {
-      meta: 'vertex'
+      meta: 'vertex',
+      id: 'baz'
     },
     geometry: {
       type: 'Point',
@@ -56,13 +70,14 @@ test('featuresAt with bounding box', t => {
   }, {
     type: 'Feature',
     properties: {
-      meta: 'feature'
+      meta: 'feature',
+      id: 'foo'
     },
     geometry: {
       type: 'LineString',
       coordinates: [[0, 0], [1, 1], [2, 2]]
     }
-  }], 'sorts, and filters out features with the right properties.meta');
+  }], 'sorts, filters based on properties.meta, removes duplicates');
 
   t.end();
 });


### PR DESCRIPTION
Fixes #509.

The problem was that `queryRenderedFeatures` was returning multiple versions of the same feature, as it can do, and we were not filtering out those duplicates. With this change I can no longer reproduce the bug.

@mcwhittemore for review.