### PR TITLE
Export UMD modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lint": "eslint --no-eslintrc -c .eslintrc index.js src test",
     "tape": "tape -r ./test/mock-browser.js -r babel-register test/*.test.js",
     "coverage": "NODE_ENV=test nyc --reporter html npm run tape && opener coverage/index.html",
-    "build": "NODE_ENV=production browserify index.js > dist/mapbox-gl-draw.js",
-    "prepublish": "NODE_ENV=production browserify index.js | uglifyjs -c -m > dist/mapbox-gl-draw.js",
+    "build": "NODE_ENV=production browserify index.js --standalone mapboxgl.Draw > dist/mapbox-gl-draw.js",
+    "prepublish": "NODE_ENV=production browserify index.js --standalone mapboxgl.Draw | uglifyjs -c -m > dist/mapbox-gl-draw.js",
     "start": "node server.js"
   },
   "repository": {


### PR DESCRIPTION
Updated the build commands to export UMD modules, which should be compatible with conventional usage, in addition to Webpack and non-module loading environments.
