### PR TITLE
'line_string' Option Correction in API Docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,7 +26,7 @@ keybindings | boolean | Keyboard shortcuts for drawing - default: `true`
 boxSelect | boolean | If true, shift + click to features. If false, click + select zooms to area - default: `true`
 clickBuffer | number | On click, include features beyond the coordinates of the click by clickBuffer value all directions - default: `2`
 displayControlsDefault | boolean | Sets default value for the control keys in the control option - default `true`
-controls | Object | Lets you hide or show individual controls. See `displayControlsDefault` for default. Available options are: `point`, `line`, `polygon`, `trash`, `combine_features` and `uncombine_features`.
+controls | Object | Lets you hide or show individual controls. See `displayControlsDefault` for default. Available options are: `point`, `line_string`, `polygon`, `trash`, `combine_features` and `uncombine_features`.
 styles | Array | An array of style objects. By default draw provides a style for you. To override this see [Styling Draw](#styling-draw) further down.
 
 ## Modes


### PR DESCRIPTION
`line` is not a valid option -- it seems that the doc is actually referring to `line_string`