### PR TITLE
Set feature property

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -175,6 +175,7 @@ module.exports = function(ctx) {
 
   api.setFeatureProperty = function(featureId, name, property) {
     ctx.store.setFeatureProperty(featureId, name, property);
+    return api;
   }
 
   return api;

--- a/src/api.js
+++ b/src/api.js
@@ -173,5 +173,9 @@ module.exports = function(ctx) {
     return api;
   };
 
+  api.setFeatureProperty = function(featureId, name, property) {
+    ctx.store.setFeatureProperty(featureId, name, property);
+  }
+
   return api;
 };

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -26,6 +26,10 @@ Feature.prototype.getCoordinates = function() {
   return JSON.parse(JSON.stringify(this.coordinates));
 };
 
+Feature.prototype.setProperty = function(name, value) {
+  this.properties[name] = value;
+}
+
 Feature.prototype.toGeoJSON = function() {
   return JSON.parse(JSON.stringify({
     id: this.id,
@@ -39,15 +43,19 @@ Feature.prototype.toGeoJSON = function() {
 };
 
 Feature.prototype.internal = function(mode) {
+  var properties = {
+    id: this.id,
+    meta: Constants.meta.FEATURE,
+    'meta:type': this.type,
+    active: Constants.activeStates.INACTIVE,
+    mode: mode
+  };
+  for (var name in this.properties) {
+    properties[name] = this.properties[name];
+  }
   return {
     type: Constants.geojsonTypes.FEATURE,
-    properties: {
-      id: this.id,
-      meta: Constants.meta.FEATURE,
-      'meta:type': this.type,
-      active: Constants.activeStates.INACTIVE,
-      mode: mode
-    },
+    properties: properties,
     geometry: {
       coordinates: this.getCoordinates(),
       type: this.type

--- a/src/store.js
+++ b/src/store.js
@@ -235,3 +235,14 @@ Store.prototype.getSelected = function() {
 Store.prototype.isSelected = function(featureId) {
   return this._selectedFeatureIds.has(featureId);
 };
+
+/** 
+ * Sets a property on the given feature
+ * @param {string} featureId
+ * @param {string} property name
+ * @param {string} property value
+*/
+Store.prototype.setFeatureProperty = function(featureId, name, value) {
+  this.get(featureId).setProperty(name, value);
+  this.featureChanged(featureId);
+};

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -611,6 +611,15 @@ test('Draw.uncombineFeatures -- should do nothing if nothing if only non multife
   t.end();
 });
 
+test('Draw.setFeatureProperty', t => {
+  Draw.add(getGeoJSON('point'));
+  const featureId = Draw.getAll().features[0].id;
+  const drawInstance = Draw.setFeatureProperty(featureId, 'price', 200);
+  t.equals(drawInstance, Draw, 'returns Draw instance');  
+  t.equals(Draw.get(featureId).properties.price, 200, 'Draw.setFeatureProperty adds a property');
+  t.end();
+});
+
 test('Cleanup', t => {
   Draw.deleteAll();
   Draw.remove();

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -25,7 +25,8 @@ test('Feature contrusctor and API', t => {
   t.equal(typeof Feature.prototype.getCoordinates, 'function', 'feature.getCoordinates');
   t.equal(typeof Feature.prototype.toGeoJSON, 'function', 'feature.toGeoJSON');
   t.equal(typeof Feature.prototype.internal, 'function', 'feature.internal');
-  t.equal(getPublicMemberKeys(Feature.prototype).length, 6, 'no unexpected prototype members');
+  t.equal(typeof Feature.prototype.setProperty, 'function', 'feature.setProperty');
+  t.equal(getPublicMemberKeys(Feature.prototype).length, 7, 'no unexpected prototype members');
 
   const simpleFeatureGeoJson = {
     type: 'Feature',
@@ -106,6 +107,8 @@ test('Feature#internal', t => {
   t.deepEqual(feature.internal('foo'), {
     type: 'Feature',
     properties: {
+      a: 'b',
+      c: 'd',
       id: feature.id,
       meta: 'feature',
       'meta:type': feature.type,

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -122,3 +122,12 @@ test('Feature#internal', t => {
   });
   t.end();
 });
+
+test('Feature#setProperty', t => {
+  const ctx = createMockCtx();
+  const polygon = createFeature('polygon');
+  const feature = new Feature(ctx, polygon);
+  feature.setProperty('size', 200);
+  t.equal(feature.properties.size, 200);
+  t.end();
+});

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -237,3 +237,17 @@ test('Store#setSelected', t => {
 
   t.end();
 });
+
+test('Store#setFeatureProperty', t => {
+  const store = createStore();
+  const point = createFeature('point');
+  
+  store.add(point);
+  store.clearChangedIds();  
+  store.setFeatureProperty(point.id, 'size', 200);
+  t.deepEqual(store.getChangedIds(), [point.id]);
+  t.equal(store.get(point.id).properties.size, 200, 'sets the property on the feature');
+
+  t.end();
+});
+

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -50,8 +50,9 @@ test('Store constructor and public API', t => {
   t.equal(typeof Store.prototype.isSelected, 'function', 'exposes store.isSelected');
   t.equal(typeof Store.prototype.delete, 'function', 'exposes store.delete');
   t.equal(typeof Store.prototype.setSelected, 'function', 'exposes store.setSelected');
+  t.equal(typeof Store.prototype.setFeatureProperty, 'function', 'exposes store.setFeatureProperty');
 
-  t.equal(getPublicMemberKeys(Store.prototype).length, 17, 'no untested prototype members');
+  t.equal(getPublicMemberKeys(Store.prototype).length, 18, 'no untested prototype members');
 
   t.end();
 });

--- a/test/utils/create_feature.js
+++ b/test/utils/create_feature.js
@@ -6,8 +6,10 @@ const hatRack = hat.rack();
 
 export default function createFeature(featureType) {
   const feature = xtend({
-    id: hatRack()
+    id: hatRack(),
+    properties: {}
   }, getGeoJSON(featureType));
   feature.toGeoJSON = () => feature;
+  feature.setProperty = (property, name) => feature.properties[property] = name;
   return feature;
 }


### PR DESCRIPTION
I have a use case where i want to show the area of a polygon in its center. With Mapbox I can configure a style to have a point layer which labels the polygon with a feature property.

As such, I have added a setter to the API to allow outside code to set an arbitrary feature property, which can then be styled by Mapbox.

This could also be useful for holding state specific to a feature inside the feature itself and saves having to write an external source of truth and keeping it in sync.

Thanks, and please let me know if there's anything I can do in relation to this PR.
Chris :)