### PR TITLE
Rename `mapboxglDraw` to `MapboxDraw`

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,7 +3,7 @@
 To use Draw
 
 ```js
-var Draw = mapboxglDraw({ options });
+var Draw = new MapboxDraw({ options });
 map.addControl(Draw);
 ```
 
@@ -79,7 +79,7 @@ Note that this mode can only be entered or exited via `.changeMode`
 
 ## API Methods
 
-`mapboxglDraw()` returns an instance of `Draw` which has the following API for working with your data:
+`new MapboxDraw()` returns an instance of `Draw` which has the following API for working with your data:
 
 ###`.add(Object: GeoJSON) -> [String]`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,26 @@
+## 0.16.0
+
+#### ⚠️ Breaking changes ⚠️
+
+- Changes `mapboxglDraw` to `MapboxDraw` to match other control names.
+- Changes `MapboxDraw()` to `new MapboxDraw()` to match other control interfaces.
+- Provides clearer icon support for drag feature in `direct_select`.
+
 ## 0.15.0
 
-- Adds support for `mapbox-gl-js@0.28.0`
-- Adds `Draw.setFeatureProperty(string, string, any)`
-- Adds `mapboxglDraw({userProperties: boolean})` to add user properties to the data rendered by Draw
-- Fixes bug where Draw would fail to attach to mapbox-gl-js if added while a style was loading
-- Fixes bug where Firefox would treat all mousemove events as drag events
+- Adds support for `mapbox-gl-js@0.28.0`.
+- Adds `Draw.setFeatureProperty(string, string, any)`.
+- Adds `mapboxglDraw({userProperties: boolean})` to add user properties to the data rendered by Draw.
+- Fixes bug where Draw would fail to attach to mapbox-gl-js if added while a style was loading.
+- Fixes bug where Firefox would treat all mousemove events as drag events.
 
 ## 0.14.0
 
 #### ⚠️ Breaking changes ⚠️
 
-- Requires [mapbox-gl@0.27.0](https://github.com/mapbox/mapbox-gl-js/blob/master/CHANGELOG.md#0270-november-11-2016)
-- Detects style changes and reapplies Draw if it has been removed
-- Fixes UMD support
+- Requires [mapbox-gl@0.27.0](https://github.com/mapbox/mapbox-gl-js/blob/master/CHANGELOG.md#0270-november-11-2016).
+- Detects style changes and reapplies Draw if it has been removed.
+- Fixes UMD support.
 - Changes `mapboxgl.Draw` to `mapboxglDraw` when in global scope.
 
 ## 0.13.2
@@ -34,7 +42,7 @@
 
 ## 0.12.1
 
-- Fix bug that broke editing multifeatures in direct_select mode after using the combine feature
+- Fix bug that broke editing MultiFeatures in `direct_select` mode after using the combine feature
 
 ## 0.12.0
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Draw ships with CSS, make sure you include it in your build. It can be found on 
 
 ```js
 var mapboxgl = require('mapbox-gl');
-var mapboxglDraw = require('mapbox-gl-draw');
+var MapboxDraw = require('mapbox-gl-draw');
 ```
 
 **When using a CDN**
@@ -45,7 +45,7 @@ var map = new mapboxgl.Map({
   zoom: 9
 });
 
-var Draw = mapboxglDraw();
+var Draw = new MapboxDraw();
 
 map.addControl(Draw)
 ```

--- a/debug/index.html
+++ b/debug/index.html
@@ -72,7 +72,7 @@ location.hash.replace(/^#/,'').split('/').reduce(function(args, val, i, hash){
 
   map.addControl(new mapboxgl.NavigationControl(), 'top-left');
 
-  var Draw = window.Draw = mapboxglDraw();
+  var Draw = window.Draw = new MapboxDraw();
   var drawIsActive = true;
   map.addControl(Draw, 'bottom-right');
 

--- a/index.js
+++ b/index.js
@@ -3,14 +3,14 @@ const setupOptions = require('./src/options');
 const setupAPI = require('./src/api');
 const Constants = require('./src/constants');
 
-const Draw = function(options) {
+const setupDraw = function(options, api) {
   options = setupOptions(options);
 
   const ctx = {
     options: options
   };
 
-  const api = setupAPI(ctx);
+  api = setupAPI(ctx, api);
   ctx.api = api;
 
   const setup = runSetup(ctx);
@@ -23,4 +23,6 @@ const Draw = function(options) {
   return api;
 };
 
-module.exports = Draw;
+module.exports = function(options) {
+  setupDraw(options, this);
+};

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lint": "eslint --no-eslintrc -c .eslintrc index.js src test",
     "tape": "tape -r ./test/mock-browser.js -r babel-register test/*.test.js",
     "coverage": "NODE_ENV=test nyc --reporter html npm run tape && opener coverage/index.html",
-    "build": "NODE_ENV=production browserify index.js --standalone mapboxglDraw > dist/mapbox-gl-draw.js",
-    "prepublish": "NODE_ENV=production browserify index.js --standalone mapboxglDraw | uglifyjs -c -m > dist/mapbox-gl-draw.js",
+    "build": "NODE_ENV=production browserify index.js --standalone MapboxDraw > dist/mapbox-gl-draw.js",
+    "prepublish": "NODE_ENV=production browserify index.js --standalone MapboxDraw | uglifyjs -c -m > dist/mapbox-gl-draw.js",
     "start": "node server.js"
   },
   "repository": {

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ var browserify = require('browserify-middleware');
 
 
 app.get('/mapbox-gl-draw.js', browserify('./index.js', {
-    standalone: 'mapboxglDraw',
+    standalone: 'MapboxDraw',
     debug: true,
     cache: 'dynamic',
     minify: false

--- a/src/api.js
+++ b/src/api.js
@@ -16,10 +16,9 @@ const featureTypes = {
   MultiPoint: require('./feature_types/multi_feature')
 };
 
-module.exports = function(ctx) {
-  const api = {
-    modes: Constants.modes
-  };
+module.exports = function(ctx, api) {
+
+  api.modes = Constants.modes;
 
   api.getFeatureIdsAt = function(point) {
     const features = featuresAt({ point }, null, ctx);

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -55,7 +55,6 @@ module.exports = function(ctx, opts) {
 
   const onVertex = function(e) {
     startDragging(e);
-    ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
     const about = e.featureTarget.properties;
     const selectedIndex = selectedCoordPaths.indexOf(about.coord_path);
     if (!isShiftDown(e) && selectedIndex === -1) {
@@ -75,7 +74,6 @@ module.exports = function(ctx, opts) {
   };
 
   const onFeature = function(e) {
-    ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
     if (selectedCoordPaths.length === 0) startDragging(e);
     else stopDragging();
   };
@@ -112,6 +110,12 @@ module.exports = function(ctx, opts) {
 
       // On mousemove that is not a drag, stop vertex movement.
       this.on('mousemove', CommonSelectors.true, e => {
+        const isFeature = CommonSelectors.isActiveFeature(e);
+        const onVertex = isVertex(e);
+        const noCoords = selectedCoordPaths.length === 0;
+        if (isFeature && noCoords) ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
+        else if (onVertex && !noCoords) ctx.ui.queueMapClasses({ mouse: Constants.cursors.MOVE });
+        else ctx.ui.queueMapClasses({ mouse: Constants.cursors.NONE });
         stopDragging(e);
       });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -2,7 +2,7 @@
 import test from 'tape';
 import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import Constants from '../src/constants';
-import setupGLDraw from '../';
+import MapboxDraw from '../';
 import createMap from './utils/create_map';
 import getGeoJSON from './utils/get_geojson';
 import setupAfterNextRender from './utils/after_next_render';
@@ -10,7 +10,7 @@ import getPublicMemberKeys from './utils/get_public_member_keys';
 
 const map = createMap();
 const afterNextRender = setupAfterNextRender(map);
-const Draw = setupGLDraw();
+const Draw = new MapboxDraw();
 map.addControl(Draw);
 const addSpy = spy(Draw, 'add');
 const deleteSpy = spy(Draw, 'delete');

--- a/test/direct_select.test.js
+++ b/test/direct_select.test.js
@@ -1,7 +1,7 @@
 /* eslint no-shadow:[0] */
 import turfCentroid from '@turf/centroid';
 import test from 'tape';
-import glDraw from '../';
+import MapboxDraw from '../';
 import click from './utils/mouse_click';
 import getGeoJSON from './utils/get_geojson';
 import createMap from './utils/create_map';
@@ -18,7 +18,7 @@ test('direct_select', t => {
   const map = createMap({ container: mapContainer });
   spy(map, 'fire');
 
-  const Draw = glDraw();
+  const Draw = new MapboxDraw();
   map.addControl(Draw);
 
   const afterNextRender = setupAfterNextRender(map);

--- a/test/draw_line_string.test.js
+++ b/test/draw_line_string.test.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 import xtend from 'xtend';
-import glDraw from '../';
+import MapboxDraw from '../';
 import mouseClick from './utils/mouse_click';
 import createMap from './utils/create_map';
 import makeMouseEvent from './utils/make_mouse_event';
@@ -214,7 +214,7 @@ test('draw_line_string interaction', t => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const map = createMap({ container });
-  const Draw = glDraw();
+  const Draw = new MapboxDraw();
   map.addControl(Draw);
   const afterNextRender = setupAfterNextRender(map);
 

--- a/test/draw_point.test.js
+++ b/test/draw_point.test.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 import xtend from 'xtend';
-import glDraw from '../';
+import MapboxDraw from '../';
 import mouseClick from './utils/mouse_click';
 import createMap from './utils/create_map';
 import makeMouseEvent from './utils/make_mouse_event';
@@ -142,7 +142,7 @@ test('draw_point interaction', t => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const map = createMap({ container });
-  const Draw = glDraw();
+  const Draw = new MapboxDraw();
   map.addControl(Draw);
 
   map.on('load', () => {

--- a/test/draw_polygon.test.js
+++ b/test/draw_polygon.test.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 import xtend from 'xtend';
-import glDraw from '../';
+import MapboxDraw from '../';
 import createMap from './utils/create_map';
 import mouseClick from './utils/mouse_click';
 import makeMouseEvent from './utils/make_mouse_event';
@@ -272,7 +272,7 @@ test('draw_polygon interaction', t => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const map = createMap({ container });
-  const Draw = glDraw();
+  const Draw = new MapboxDraw();
   map.addControl(Draw);
 
   map.on('load', () => {

--- a/test/interaction_events.test.js
+++ b/test/interaction_events.test.js
@@ -4,7 +4,7 @@ import test from 'tape';
 import xtend from 'xtend';
 import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import createSyntheticEvent from 'synthetic-dom-events';
-import glDraw from '../';
+import MapboxDraw from '../';
 import click from './utils/mouse_click';
 import createMap from './utils/create_map';
 import createAfterNextRender from './utils/after_next_render';
@@ -15,7 +15,7 @@ document.body.appendChild(container);
 const map = createMap({ container });
 const fireSpy = spy(map, 'fire');
 const afterNextRender = createAfterNextRender(map);
-const Draw = glDraw();
+const Draw = new MapboxDraw();
 const onAdd = Draw.onAdd.bind(Draw);
 let controlGroup = null;
 Draw.onAdd = function(m) {

--- a/test/line_string.test.js
+++ b/test/line_string.test.js
@@ -2,7 +2,7 @@ import test from 'tape';
 import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import Feature from '../src/feature_types/feature';
 import LineString from '../src/feature_types/line_string';
-import glDraw from '../';
+import MapboxDraw from '../';
 import createFeature from './utils/create_feature';
 import getPublicMemberKeys from './utils/get_public_member_keys';
 import createMockCtx from './utils/create_mock_feature_context';
@@ -110,7 +110,7 @@ test('LineString#updateCoordinate', t => {
 test('LineString integration', t => {
   const lineStringCoordinates = [[0, 0], [40, 20], [20, 40]];
   const map = createMap();
-  const Draw = glDraw();
+  const Draw = new MapboxDraw();
   map.addControl(Draw);
 
   map.on('load', () => {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,11 +1,11 @@
 /* eslint no-shadow:[0] */
 import test from 'tape';
-import glDraw from '../';
+import MapboxDraw from '../';
 import styleWithSourcesFixture from './fixtures/style_with_sources.json';
 
 test('Options test', t => {
   t.test('no options', t => {
-    const Draw = glDraw();
+    const Draw = new MapboxDraw();
     const defaultOptions = {
       defaultMode: 'simple_select',
       keybindings: true,
@@ -29,7 +29,7 @@ test('Options test', t => {
   });
 
   t.test('use custom clickBuffer', t => {
-    const Draw = glDraw({ clickBuffer: 10 });
+    const Draw = new MapboxDraw({ clickBuffer: 10 });
     const defaultOptions = {
       defaultMode: 'simple_select',
       keybindings: true,
@@ -53,7 +53,7 @@ test('Options test', t => {
   });
 
   t.test('hide all controls', t => {
-    const Draw = glDraw({displayControlsDefault: false});
+    const Draw = new MapboxDraw({displayControlsDefault: false});
     const defaultOptions = {
       defaultMode: 'simple_select',
       keybindings: true,
@@ -76,7 +76,7 @@ test('Options test', t => {
   });
 
   t.test('hide controls but show point', t => {
-    const Draw = glDraw({displayControlsDefault: false, controls: {point:true}});
+    const Draw = new MapboxDraw({displayControlsDefault: false, controls: {point:true}});
     const defaultOptions = {
       defaultMode: 'simple_select',
       keybindings: true,
@@ -100,7 +100,7 @@ test('Options test', t => {
   });
 
   t.test('hide only point control', t => {
-    const Draw = glDraw({ controls: {point:false}});
+    const Draw = new MapboxDraw({ controls: {point:false}});
     const defaultOptions = {
       defaultMode: 'simple_select',
       keybindings: true,
@@ -124,7 +124,7 @@ test('Options test', t => {
   });
 
   t.test('custom styles', t => {
-    const Draw = glDraw({styles: [{
+    const Draw = new MapboxDraw({styles: [{
       'id': 'custom-polygon',
       'type': 'fill',
       'filter': ['all', ['==', '$type', 'Polygon']],

--- a/test/point.test.js
+++ b/test/point.test.js
@@ -2,7 +2,7 @@ import test from 'tape';
 import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import Feature from '../src/feature_types/feature';
 import Point from '../src/feature_types/point';
-import glDraw from '../';
+import MapboxDraw from '../';
 import createFeature from './utils/create_feature';
 import getPublicMemberKeys from './utils/get_public_member_keys';
 import createMockCtx from './utils/create_mock_feature_context';
@@ -72,7 +72,7 @@ test('Point#updateCoordinate, Point#getCoordinate', t => {
 test('Point integration test', t => {
   const pointCoordinates = [10, 10];
   const map = createMap();
-  const Draw = glDraw();
+  const Draw = new MapboxDraw();
   map.addControl(Draw);
 
   map.on('load', () => {

--- a/test/polygon.test.js
+++ b/test/polygon.test.js
@@ -2,7 +2,7 @@ import test from 'tape';
 import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import Feature from '../src/feature_types/feature';
 import Polygon from '../src/feature_types/polygon';
-import glDraw from '../';
+import MapboxDraw from '../';
 import createFeature from './utils/create_feature';
 import getPublicMemberKeys from './utils/get_public_member_keys';
 import createMockCtx from './utils/create_mock_feature_context';
@@ -134,7 +134,7 @@ test('Polygon#updateCoordinate, Polygon#getCoordinate', t => {
 test('Polygon integration', t => {
   const polygonCoordinates = [[[0, 0], [30, 15], [30, 30], [15, 30], [0, 0]]];
   const map = createMap();
-  const Draw = glDraw();
+  const Draw = new MapboxDraw();
   map.addControl(Draw);
 
   map.on('load', () => {

--- a/test/simple_select.test.js
+++ b/test/simple_select.test.js
@@ -1,6 +1,6 @@
 /* eslint no-shadow:[0] */
 import test from 'tape';
-import glDraw from '../';
+import MapboxDraw from '../';
 import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import setupAfterNextRender from './utils/after_next_render';
 import makeMouseEvent from './utils/make_mouse_event';
@@ -19,7 +19,7 @@ test('simple_select', t => {
   spy(map.dragPan, 'enable');
   spy(map.dragPan, 'disable');
 
-  const Draw = glDraw();
+  const Draw = new MapboxDraw();
   map.addControl(Draw);
 
   const afterNextRender = setupAfterNextRender(map);

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1,6 +1,6 @@
 /* eslint no-shadow:[0] */
 import test from 'tape';
-import glDraw from '../';
+import MapboxDraw from '../';
 import spy from 'sinon/lib/sinon/spy'; // avoid babel-register-related error by importing only spy
 import setupAfterNextRender from './utils/after_next_render';
 import makeMouseEvent from './utils/make_mouse_event';
@@ -15,7 +15,7 @@ test('static', t => {
   map.dragPan.disable.restore();
   spy(map.dragPan, 'disable');
 
-  const Draw = glDraw();
+  const Draw = new MapboxDraw();
   map.addControl(Draw);
 
   const afterNextRender = setupAfterNextRender(map);


### PR DESCRIPTION
This PR renames draw for the last time!

In the other Mapbox maintained `mapbox-gl-js` controls we have settled on the `new MapboxNoun()` convention. This PR brings `MapboxDraw` into accord.

**Breaking Changes**

- The name has changed for `script tag` users.
- `MapboxDraw` now requires `new`.