### PR TITLE
Update mapbox-gl peerDependencies to 0.29.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Adds support for drawing and editing features on [mapbox-gl.js](https://www.mapb
 
 [![Circle CI](https://circleci.com/gh/mapbox/mapbox-gl-draw/tree/master.svg?style=svg)](https://circleci.com/gh/mapbox/gl-draw/tree/master)
 
-**Requires [mapbox-gl-js@0.27.0](https://github.com/mapbox/mapbox-gl-js/blob/master/CHANGELOG.md#0270-november-11-2016) or higher.**
+**Requires [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js) (version 0.27.0 – 0.29.x).**
 
 ### Installing
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "unassertify": "^2.0.3"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.27.0 || ^0.28.0"
+    "mapbox-gl": "^0.27.0 || ^0.28.0 || ^0.29.0"
   },
   "dependencies": {
     "geojson-area": "^0.2.1",


### PR DESCRIPTION
The peerDependencies do not include the latest Mapbox GL JS version, which causes an annoying nag when using npm.