### PR TITLE
update peer dependencies for mapbox-gl

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "unassertify": "^2.0.3"
   },
   "peerDependencies": {
-    "mapbox-gl": ">=0.27.0 <=0.32.1"
+    "mapbox-gl": ">=0.27.0 <=0.34.0"
   },
   "dependencies": {
     "@mapbox/geojson-area": "^0.2.1",


### PR DESCRIPTION
Updates the `mapbox-gl` peer dependency to work with the latest version of GLJS. 

Also, greenkeeper appears to have updated all dependencies.

cc @mcwhittemore 