### PR TITLE
version 0.17.1 bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-draw",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A drawing component for Mapbox GL JS",
   "homepage": "https://github.com/mapbox/mapbox-gl-draw",
   "author": "mapbox",


### PR DESCRIPTION
Version bump for last [merge](https://github.com/mapbox/mapbox-gl-draw/pull/619) with new dependencies and peer dependencies.