### PR TITLE
Don't cache selected points separately from other store features

### DIFF
--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -78,7 +78,7 @@ module.exports = function(ctx, opts) {
   };
 
   function pathsToCoordinates(featureId, paths) {
-    return paths.map(coord_path => { return { feature_id: featureId, coord_path, coordinates: feature.getCoordinate(coord_path) }; });
+    return paths.map(coord_path => { return { feature_id: featureId, coord_path }; });
   }
 
   const onFeature = function(e) {

--- a/src/store.js
+++ b/src/store.js
@@ -257,7 +257,13 @@ Store.prototype.getSelected = function() {
  * @return {Array<Object>} Selected coordinates.
  */
 Store.prototype.getSelectedCoordinates = function() {
-  return this._selectedCoordinates;
+  const selected = this._selectedCoordinates.map(coordinate => {
+    const feature = this.get(coordinate.feature_id);
+    return {
+      coordinates: feature.getCoordinate(coordinate.coord_path)
+    };
+  });
+  return selected;
 };
 
 /**


### PR DESCRIPTION
The goal of this PR is to close #632 

### Summary

In `direct_select` mode, entering the mode or clicking on a vertex saves the parent feature ID, the coordinate index, and the geometry of the selected vertex.

When a user drags the point, the point remains selected, but it's geometry value saved to the store remains the same. So calling `draw.getSelectedPoints` inside of a `draw.update` event handler will frequently return stale geometry.

To fix this, I make the `store._getSelectedCoordinates` method retrieve the coordinate geometry based on the store's (up-to-date) features, rather than the cached value in `store._selectedCoordinates`.

I also stop including coordinates in the `_selectedCoordinates` array at all, so that `direct_select` now only saves the parent feature ID and coordinate index of the selected vertex (or vertices).