### PR TITLE
include npm run prepublish in publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ npm run test
 To github and npm
 
 ```
+npm run prepublish
 npm version (major|minor|patch)
 git push --tags
 git push


### PR DESCRIPTION
See https://github.com/mapbox/mapbox-gl-draw/issues/637#issuecomment-301435761 for background.

Aims to ensure #637 is fixed in the next release.