### PR TITLE
Change package.json to point to compiled files instead of source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/mapbox/mapbox-gl-draw",
   "author": "mapbox",
   "license": "ISC",
-  "main": "index.js",
+  "main": "dist/mapbox-gl-draw.js",
   "browserify": {
     "transform": [
       "babelify"


### PR DESCRIPTION
As it stands right now we have to override this in Webpack in order to target ES5. Is there any reason not to point `package.json` at the compiled files?

```
{
    // ...
    resolve: {
        alias: {
            "@mapbox/mapbox-gl-draw": path.resolve(__dirname, "../node_modules/@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.js"),
        },
    },
    // ...
}
```