### PR TITLE
Fix touch events issue and the trash behaviour

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -83,7 +83,9 @@ module.exports = function(ctx) {
   events.touchstart = function(event) {
     // Prevent emulated mouse events because we will fully handle the touch here.
     // This does not stop the touch events from propogating to mapbox though.
-    event.originalEvent.preventDefault();
+    if (currentModeName !== Constants.modes.SIMPLE_SELECT) {
+      event.originalEvent.preventDefault();
+    }
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -98,7 +100,9 @@ module.exports = function(ctx) {
   };
 
   events.touchmove = function(event) {
-    event.originalEvent.preventDefault();
+    if (currentModeName !== Constants.modes.SIMPLE_SELECT) {
+      event.originalEvent.preventDefault();
+    }
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -108,7 +112,9 @@ module.exports = function(ctx) {
   };
 
   events.touchend = function(event) {
-    event.originalEvent.preventDefault();
+    if (currentModeName !== Constants.modes.SIMPLE_SELECT) {
+      event.originalEvent.preventDefault();
+    }
     if (!ctx.options.touchEnabled) {
       return;
     }

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -201,18 +201,9 @@ module.exports = function(ctx, opts) {
       fireActionable();
     },
     trash: function() {
-      selectedCoordPaths.sort().reverse().forEach(id => feature.removeCoordinate(id));
-      ctx.map.fire(Constants.events.UPDATE, {
-        action: Constants.updateActions.CHANGE_COORDINATES,
-        features: ctx.store.getSelected().map(f => f.toGeoJSON())
-      });
-      selectedCoordPaths = [];
-      ctx.store.clearSelectedCoordinates();
+      ctx.store.delete(ctx.store.getSelectedIds());
       fireActionable();
-      if (feature.isValid() === false) {
-        ctx.store.delete([featureId]);
-        ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, {});
-      }
+      ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, {});
     }
   };
 };


### PR DESCRIPTION
Fix the behaviour of the trash button in "direct select" mode: it should just trash the selected feature as in "simple select" mode.
Fix touch behaviour: do not prevent default of touch events in "simple select" mode to let the click on any map features work (not only draw features).