### PR TITLE
Safely Remove Control

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -6,9 +6,14 @@ const Constants = require('./constants');
 module.exports = function(ctx) {
 
   let controlContainer = null;
+  let mapLoadedInterval = null;
 
   const setup = {
     onRemove: function() {
+      // Stop connect attempt in the event that control is removed before map is loaded
+      ctx.map.off('load', setup.connect);
+      clearInterval(mapLoadedInterval);
+
       setup.removeLayers();
       ctx.ui.removeButtons();
       ctx.events.removeEventListeners();
@@ -20,6 +25,12 @@ module.exports = function(ctx) {
       controlContainer = null;
 
       return this;
+    },
+    connect: function() {
+      ctx.map.off('load', setup.connect);
+      clearInterval(mapLoadedInterval);
+      setup.addLayers();
+      ctx.events.addEventListeners();
     },
     onAdd: function(map) {
       ctx.map = map;
@@ -38,20 +49,11 @@ module.exports = function(ctx) {
         map.dragPan.enable();
       }
 
-      let intervalId = null;
-
-      const connect = () => {
-        map.off('load', connect);
-        clearInterval(intervalId);
-        setup.addLayers();
-        ctx.events.addEventListeners();
-      };
-
       if (map.loaded()) {
-        connect();
+        setup.connect();
       } else {
-        map.on('load', connect);
-        intervalId = setInterval(() => { if (map.loaded()) connect(); }, 16);
+        map.on('load', setup.connect);
+        mapLoadedInterval = setInterval(() => { if (map.loaded()) setup.connect(); }, 16);
       }
 
       ctx.events.start();
@@ -82,13 +84,22 @@ module.exports = function(ctx) {
 
       ctx.store.render();
     },
+    // Check for layers and sources before attempting to remove
+    // If user adds draw control and removes it before the map is loaded, layers and sources will be missing
     removeLayers: function() {
       ctx.options.styles.forEach(style => {
-        ctx.map.removeLayer(style.id);
+        if (ctx.map.getLayer(style.id)) {
+          ctx.map.removeLayer(style.id);
+        }
       });
 
-      ctx.map.removeSource(Constants.sources.COLD);
-      ctx.map.removeSource(Constants.sources.HOT);
+      if (ctx.map.getSource(Constants.sources.COLD)) {
+        ctx.map.removeSource(Constants.sources.COLD);
+      }
+
+      if (ctx.map.getSource(Constants.sources.HOT)) {
+        ctx.map.removeSource(Constants.sources.HOT);
+      }
     }
   };
 


### PR DESCRIPTION
Removing the draw control before the map is loaded throws errors related to missing layers.

This PR introduces a two part solution:

1. When the control is removed, stop waiting for map to load.
1. Check for source/layer presence before attempting to remove them.

fixes #572 

I would love feedback.