### PR TITLE
Remove console log and add eslint rule to prevent repeat

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,8 @@
     "quotes": "off",
     "space-before-function-paren": "off",
     "template-curly-spacing": "error",
-    "camelcase": 0
+    "camelcase": 0,
+    "no-console": ["error", { "allow": ["warn", "error"] }]
   },
   "env": {
     "es6": true,

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -268,7 +268,6 @@ test('Store#storeAndRestoreMapConfig', t => {
   const store = new Store(ctx);
   store.storeMapConfig();
   // Check we can get the initial state of it
-  console.log(store);
   t.equal(store.getInitialConfigValue('doubleClickZoom'), false, 'Retrieves the initial value for the doubleClickZoom');
   // Enable it again, byt then use restore to reset the initial state
   map.doubleClickZoom.enable();


### PR DESCRIPTION
Very small change to add an eslint rule to catch leftover `console.log`s. Also remove a `console.log` in a previous PR.