### PR TITLE
Update npm peer dependencies to mapbox-gl <=0.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "unassertify": "^2.0.3"
   },
   "peerDependencies": {
-    "mapbox-gl": ">=0.27.0 <=0.41.0"
+    "mapbox-gl": ">=0.27.0 <=0.43.0"
   },
   "dependencies": {
     "@mapbox/geojson-area": "^0.2.1",


### PR DESCRIPTION
Update npm peer dependency to mapbox-gl 0.43.0 to prevent a npm warning.