### PR TITLE
Add example of adding draw mode to draw

### DIFF
--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -49,12 +49,13 @@ LotsOfPointsMode.toDisplayFeatures = function(state, geojson, display) {
   display(geojson);
 };
 
-// Add the new draw mode to the mapbox Draw object
+// Add the new draw mode to the MapboxDraw object
 var draw = new MapboxDraw({
   defaultMode: 'lots_of_points',
-  modes: {
+  // Adds the LotsOfPointsMode to the built-in set of modes
+  modes: Object.assign({
     lots_of_points: LotsOfPointsMode,
-  },
+  }, MapboxDraw.modes),
 });
 ```
 

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -48,6 +48,14 @@ LotsOfPointsMode.onKeyUp = function(state, e) {
 LotsOfPointsMode.toDisplayFeatures = function(state, geojson, display) {
   display(geojson);
 };
+
+// Add the new draw mode to the mapbox Draw object
+var draw = new MapboxDraw({
+  defaultMode: 'lots_of_points',
+  modes: {
+    lots_of_points: LotsOfPointsMode,
+  },
+})
 ```
 
 For more info on how to handle map interactions see [Life Cycle Functions](#life-cycle-functions). For more info on how to interact with Draw's internal state see [Setters & Getters](#setters-and-getters).

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -55,7 +55,7 @@ var draw = new MapboxDraw({
   modes: {
     lots_of_points: LotsOfPointsMode,
   },
-})
+});
 ```
 
 For more info on how to handle map interactions see [Life Cycle Functions](#life-cycle-functions). For more info on how to interact with Draw's internal state see [Setters & Getters](#setters-and-getters).


### PR DESCRIPTION
This wasn't totally clear to me when I went about building a new draw mode. I realize that `defaultMode` and `modes` are documented in a different file, but it still tripped me up because it didn't quite click as to how I'd hook the mode in. Just  a suggestion, feel free to close or modify.