### PR TITLE
Race condition loading shapes

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -79,8 +79,8 @@ module.exports = function render() {
     });
   }
 
-  store.ctx.map.fire(Constants.events.RENDER, {});
   cleanup();
+  store.ctx.map.fire(Constants.events.RENDER, {});
 
   function cleanup() {
     store.isDirty = false;

--- a/src/setup.js
+++ b/src/setup.js
@@ -83,6 +83,7 @@ module.exports = function(ctx) {
         ctx.map.addLayer(style);
       });
 
+      ctx.store.setDirty(true);
       ctx.store.render();
     },
     removeLayers: function() {


### PR DESCRIPTION
As outlined in my support request, we are unable to make Mapbox Draw correctly render features added before the control has fully loaded, but there are no events or otherwise to properly indicate that the control is ready.

This PR forces the `ctx.store` to be dirty when doing the initial rendering following adding its layers.

The issue is that the `render` `cleanup()` function is being called even if the map isn't ready yet, and this function sets `store.isDirty=false`, meaning that any unrendered features are ignored.

I've also changed the order of operations for the `draw.render` event for a similar reason, so that changes made to the draw instance in response to this event aren't immediately forgotten.