### PR TITLE
event.srcElement has limited support so fall back to event.target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6
+
+- Fixes bug where event.srcElement is not defined in Firefox  [#752](https://github.com/mapbox/mapbox-gl-draw/pull/752) via [@pastcompute](https://github.com/pastcompute)
+
 ## 1.0.5
 
 - update browserify to version 15.0.0 [#731](https://github.com/mapbox/mapbox-gl-draw/pull/731)

--- a/src/events.js
+++ b/src/events.js
@@ -127,7 +127,7 @@ module.exports = function(ctx) {
   const isKeyModeValid = (code) => !(code === 8 || code === 46 || (code >= 48 && code <= 57));
 
   events.keydown = function(event) {
-    if (event.srcElement.classList[0] !== 'mapboxgl-canvas') return; // we only handle events on the map
+    if ((event.srcElement || event.target).classList[0] !== 'mapboxgl-canvas') return; // we only handle events on the map
 
     if ((event.keyCode === 8 || event.keyCode === 46) && ctx.options.controls.trash) {
       event.preventDefault();


### PR DESCRIPTION
Fixes #751.

Note, I'm still trying to build the 1.0.5 git working copy (npm install fails on gulp-sourcemaps, so I cant actually build the master branch at this moment...), so proper testing is limited at this stage. beyond what I also hand-patched in my build