### PR TITLE
Don't run render on unused event handlers

### DIFF
--- a/src/modes/object_to_mode.js
+++ b/src/modes/object_to_mode.js
@@ -1,5 +1,22 @@
 const ModeInterface = require('./mode_interface');
 
+const eventMapper = {
+  drag: 'onDrag',
+  click: 'onClick',
+  mousemove: 'onMouseMove',
+  mousedown: 'onMouseDown',
+  mouseup: 'onMouseUp',
+  mouseout: 'onMouseOut',
+  keyup: 'onKeyUp',
+  keydown: 'onKeyDown',
+  touchstart: 'onTouchStart',
+  touchmove: 'onTouchMove',
+  touchend: 'onTouchEnd',
+  tap: 'onTap'
+};
+
+const eventKeys = Object.keys(eventMapper);
+
 module.exports = function(modeObject) {
   const modeObjectKeys = Object.keys(modeObject);
 
@@ -20,18 +37,21 @@ module.exports = function(modeObject) {
     return {
       start: function() {
         state = mode.onSetup(startOpts); // this should set ui buttons
-        this.on('drag', () => true, wrapper('onDrag'));
-        this.on('click', () => true, wrapper('onClick'));
-        this.on('mousemove', () => true, wrapper('onMouseMove'));
-        this.on('mousedown', () => true, wrapper('onMouseDown'));
-        this.on('mouseup', () => true, wrapper('onMouseUp'));
-        this.on('mouseout', () => true, wrapper('onMouseOut'));
-        this.on('keyup', () => true, wrapper('onKeyUp'));
-        this.on('keydown', () => true, wrapper('onKeyDown'));
-        this.on('touchstart', () => true, wrapper('onTouchStart'));
-        this.on('touchmove', () => true, wrapper('onTouchMove'));
-        this.on('touchend', () => true, wrapper('onTouchEnd'));
-        this.on('tap', () => true, wrapper('onTap'));
+
+        // Adds event handlers for all event options
+        // add sets the selector to false for all
+        // handlers that are not present in the mode
+        // to reduce on render calls for functions that
+        // have no logic
+        eventKeys.forEach(key => {
+          const modeHandler = eventMapper[key];
+          let selector = () => false;
+          if (modeObject[modeHandler]) {
+            selector = () => true;
+          }
+          this.on(key, selector, wrapper(modeHandler));
+        });
+
       },
       stop: function() {
         mode.onStop(state);


### PR DESCRIPTION
Updates the mode to object code which converts an object following the mode interface into Draw's internal concept mode concept. The update makes sure that the selector for all events inherited from the interface is set to false so that the empty function code of the interface won't run.

This will reduce the amount of extra render calls as events that aren't directly implemented by a mode won't force renders anymore, but it does not solve #760 as any event handler implemented by a mode will still force a render even if that event handler does nothing to the source data.

This change means that the static custom mode will only force a render on setup.

@hyperknot if you can review that this solves your CPU problem in the static mode context that would be great.