### PR TITLE
Allow dry run of move_feature

### DIFF
--- a/src/lib/move_features.js
+++ b/src/lib/move_features.js
@@ -1,10 +1,10 @@
 const constrainFeatureMovement = require('./constrain_feature_movement');
 const Constants = require('../constants');
 
-module.exports = function(features, delta) {
+module.exports = function(features, delta, isDryRun=false) {
   const constrainedDelta = constrainFeatureMovement(features.map(feature => feature.toGeoJSON()), delta);
 
-  features.forEach(feature => {
+  return features.map(feature => {
     const currentCoordinates = feature.getCoordinates();
 
     const moveCoordinate = (coord) => {
@@ -28,6 +28,9 @@ module.exports = function(features, delta) {
       nextCoordinates = currentCoordinates.map(moveMultiPolygon);
     }
 
-    feature.incomingCoords(nextCoordinates);
+    if (!isDryRun) {
+      feature.incomingCoords(nextCoordinates);
+    }
+    return nextCoordinates;
   });
 };


### PR DESCRIPTION
If overriding the `dragMove` (simple_select)/`dragFeature` (direct_select) methods to create custom drag behavior, it is necessary to see what the new dragged coordinates are before actually dragging.  For example, I do not want the dragged feature(s) to be dragged outside of a set bounding area.

Rough example of usage:
```
import booleanContains from '@turf/boolean-contains';
import { polygon } from '@turf/helpers';

// ....

const delta = {
  lng: e.lngLat.lng - state.dragMoveLocation.lng,
  lat: e.lngLat.lat - state.dragMoveLocation.lat
};
const movedCoordinates = moveFeatures(this.getSelected(), delta, true);
const isInBounds = booleanContains(boundsPolygon, polygon(movedCoordinates[0]));
// then, perform drag for real
```