### PR TITLE
Remove overridden/dupe onMouseUp in SimpleSelect

### DIFF
--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -99,11 +99,6 @@ SimpleSelect.onStop = function() {
   doubleClickZoom.enable(this);
 };
 
-SimpleSelect.onMouseUp = function(state, e) {
-  // Any mouseup should stop box selecting and dragMoving
-  if (CommonSelectors.true(e)) return this.stopExtendedInteractions(state);
-};
-
 SimpleSelect.onMouseMove = function(state) {
   // On mousemove that is not a drag, stop extended interactions.
   // This is useful if you drag off the canvas, release the button,


### PR DESCRIPTION
Removing this block as it is overridden by this:
https://github.com/mapbox/mapbox-gl-draw/blob/master/src/modes/simple_select.js#L268-L288

Presumably the second block is the one to be used.