### PR TITLE
Include userProperties in Options section of docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -35,6 +35,7 @@ All of the following options are optional.
 - `styles`, Array\<Object\>: An array of map style objects. By default, Draw provides a map style for you. To learn about overriding styles, see the [Styling Draw](#styling-draw) section below.
 - `modes`, Object: over ride the default modes with your own. `MapboxDraw.modes` can be used to see the default values. More information on custom modes [can be found here](https://github.com/mapbox/mapbox-gl-draw/blob/master/docs/MODES.md).
 - `defaultMode`, String (default: `'simple_select'`): the mode (from `modes`) that user will first land in.
+- `userProperties`, boolean (default: `false`): properties of a feature will also be available for styling and prefixed with `user_`, e.g., `['==', 'user_custom_label', 'Example']`
 
 ## Modes
 


### PR DESCRIPTION
While this is mentioned in the bottom of the API.md in the styling section, it was not included as part of the section that lists all of the available options.