### PR TITLE
Enable touch event propagation

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -78,9 +78,6 @@ module.exports = function(ctx) {
   };
 
   events.touchstart = function(event) {
-    // Prevent emulated mouse events because we will fully handle the touch here.
-    // This does not stop the touch events from propogating to mapbox though.
-    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }


### PR DESCRIPTION
Touch events are inexplicably prevent from propagating while mouse clicks propagate fine.
Fix for #617

Requires testing across some more devices.