### PR TITLE
change ordering of spy creation to avoid overwrites

### DIFF
--- a/test/direct_select.test.js
+++ b/test/direct_select.test.js
@@ -18,10 +18,11 @@ test('direct_select', t => {
   const mapContainer = document.createElement('div');
   document.body.appendChild(mapContainer);
   const map = createMap({ container: mapContainer });
-  spy(map, 'fire');
 
   const Draw = new MapboxDraw();
   map.addControl(Draw);
+
+  spy(map, 'fire');
 
   const afterNextRender = setupAfterNextRender(map);
 

--- a/test/simple_select.test.js
+++ b/test/simple_select.test.js
@@ -16,14 +16,15 @@ test('simple_select', t => {
   const mapContainer = document.createElement('div');
   document.body.appendChild(mapContainer);
   const map = createMap({ container: mapContainer });
+
+  const Draw = new MapboxDraw();
+  map.addControl(Draw);
+
   spy(map, 'fire');
   spy(map.doubleClickZoom, 'enable');
   spy(map.doubleClickZoom, 'disable');
   spy(map.dragPan, 'enable');
   spy(map.dragPan, 'disable');
-
-  const Draw = new MapboxDraw();
-  map.addControl(Draw);
 
   const afterNextRender = setupAfterNextRender(map);
 

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -10,10 +10,6 @@ import createMap from './utils/create_map';
 test('static', t => {
 
   const map = createMap();
-  spy(map, 'fire');
-  map.dragPan.disable();
-  spy(map.dragPan, 'disable');
-
   const opts = {
     modes: {
       static: require('@mapbox/mapbox-gl-draw-static-mode')
@@ -22,6 +18,10 @@ test('static', t => {
   };
   const Draw = new MapboxDraw(opts);
   map.addControl(Draw);
+
+  spy(map, 'fire');
+  map.dragPan.disable();
+  spy(map.dragPan, 'disable');
 
   const afterNextRender = setupAfterNextRender(map);
 


### PR DESCRIPTION
Several Sinon tests were failing (`direct_select`, `simple_select`, and `static`) with the error [spyFunction].reset is not a function, as described in #838.

Changing the order of the spy setup call to after the calls to `map.addControl(Draw);` appears to fix the problem. It seems probable that the adding the control somehow overwrites the spy function, and so spying after addition avoids this situation. Failing tests run successfully after the swap.