### PR TITLE
Upgrade mapbox-gl peer dependency to match dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "unassertify": "^2.0.3"
   },
   "peerDependencies": {
-    "mapbox-gl": ">=0.27.0 <=0.45.0"
+    "mapbox-gl": ">=0.27.0 <=0.51.0"
   },
   "dependencies": {
     "@mapbox/geojson-area": "^0.2.1",


### PR DESCRIPTION
@ansis it would be great if we still can get this into the 1.1.0 release. It seems like you haven't published on npm.

This fixes https://github.com/mapbox/mapbox-gl-draw/issues/827