### PR TITLE
Fixed old version browser const issue

### DIFF
--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -52,7 +52,7 @@ Feature.prototype.internal = function(mode) {
   };
 
   if (this.ctx.options.userProperties) {
-    for (const name in this.properties) {
+    for (let name in this.properties) {
       properties[`user_${name}`] = this.properties[name];
     }
   }


### PR DESCRIPTION
I am getting syntax Error for old version browsers

Error Message:

SyntaxError: missing = in const declaration

I checked why this is coming . https://github.com/mapbox/mapbox-gl-draw/blob/master/src/feature_types/feature.js in this file const using the loop

if (this.ctx.options.userProperties) {
for (const name in this.properties) {
properties[user_${name}] = this.properties[name];
}
}

Could to change to const to let.

Reference : https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Errors/Missing_initializer_in_const

Fix for #823 