### PR TITLE
change install instructions to yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Install dependencies, build the source files and crank up a server via:
 
 ```
 git clone git@github.com:mapbox/mapbox-gl-draw.git
-npm install
-npm start & open http://localhost:9967/debug/?access_token=<token>
+yarn install
+yarn start & open "http://localhost:9967/debug/?access_token=<token>"
 ```
 
 ### Testing


### PR DESCRIPTION
based on https://github.com/mapbox/mapbox-gl-draw/commits/master/yarn.lock things were changed to use yarn, but the install instructions for local development still used npm which doesn't read yarn.lock, leading to building with the wrong dependency versions