### PR TITLE
Update mode_interface_accessors.js

### DIFF
--- a/src/modes/mode_interface_accessors.js
+++ b/src/modes/mode_interface_accessors.js
@@ -95,10 +95,10 @@ ModeInterface.prototype.deselect = function(id) {
 /**
  * Delete a feature from draw
  * @name this.deleteFeature
- * @param {String} id - a feature id
+ * @param {string | Array<string>} featureIds
  */
-ModeInterface.prototype.deleteFeature = function(id, opts = {}) {
-  return this._ctx.store.delete(id, opts);
+ModeInterface.prototype.deleteFeature = function(featureIds, opts = {}) {
+  return this._ctx.store.delete(featureIds, opts);
 };
 
 /**


### PR DESCRIPTION
This updates the definition of `ModeInterface.prototype.deleteFeature` to match `this._ctx.store.delete` (https://github.com/mapbox/mapbox-gl-draw/blob/master/src/store.js#L107)

Specifically, that a string _or_ array of strings are accepted.

FYI, `this.deleteFeature` is called in lots of places throughout the code, passing an array with a single ID, which is both a type error at the moment and also unnecessary. But I haven't touched any of those.