### PR TITLE
draw buttons should cancel on toggle

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -69,6 +69,7 @@ module.exports = function(ctx) {
       const clickedButton = e.target;
       if (clickedButton === activeButton) {
         deactivateButtons();
+        options.onDeactivate();
         return;
       }
 
@@ -109,7 +110,8 @@ module.exports = function(ctx) {
         container: controlGroup,
         className: Constants.classes.CONTROL_BUTTON_LINE,
         title: `LineString tool ${ctx.options.keybindings ? '(l)' : ''}`,
-        onActivate: () => ctx.events.changeMode(Constants.modes.DRAW_LINE_STRING)
+        onActivate: () => ctx.events.changeMode(Constants.modes.DRAW_LINE_STRING),
+        onDeactivate: () => ctx.events.trash()
       });
     }
 
@@ -118,7 +120,8 @@ module.exports = function(ctx) {
         container: controlGroup,
         className: Constants.classes.CONTROL_BUTTON_POLYGON,
         title: `Polygon tool ${ctx.options.keybindings ? '(p)' : ''}`,
-        onActivate: () => ctx.events.changeMode(Constants.modes.DRAW_POLYGON)
+        onActivate: () => ctx.events.changeMode(Constants.modes.DRAW_POLYGON),
+        onDeactivate: () => ctx.events.trash()
       });
     }
 
@@ -127,7 +130,8 @@ module.exports = function(ctx) {
         container: controlGroup,
         className: Constants.classes.CONTROL_BUTTON_POINT,
         title: `Marker tool ${ctx.options.keybindings ? '(m)' : ''}`,
-        onActivate: () => ctx.events.changeMode(Constants.modes.DRAW_POINT)
+        onActivate: () => ctx.events.changeMode(Constants.modes.DRAW_POINT),
+        onDeactivate: () => ctx.events.trash()
       });
     }
 


### PR DESCRIPTION
Relates to this issue https://github.com/mapbox/mapbox-gl-draw/issues/698. The buttons should actually toggle the mode you're in since it toggles `active` css class. If this makes sense I can modify the tests