### PR TITLE
Fix selection event in direct_select w/ coordPath

### DIFF
--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -132,8 +132,8 @@ DirectSelect.onSetup = function(opts) {
     selectedCoordPaths: opts.coordPath ? [opts.coordPath] : []
   };
 
-  this.setSelectedCoordinates(this.pathsToCoordinates(featureId, state.selectedCoordPaths));
   this.setSelected(featureId);
+  this.setSelectedCoordinates(this.pathsToCoordinates(featureId, state.selectedCoordPaths));
   doubleClickZoom.disable(this);
 
   this.setActionableState({

--- a/test/direct_select.test.js
+++ b/test/direct_select.test.js
@@ -246,6 +246,31 @@ test('direct_select', t => {
     });
   });
 
+  t.test('direct_select - fire a selectionchange with the point provided in the coordPath', st => {
+    map.fire.reset();
+    const [lineId] = Draw.add(getGeoJSON('line'));
+
+    Draw.changeMode(Constants.modes.DIRECT_SELECT, {
+      featureId: lineId,
+      coordPath: '0'
+    });
+
+    afterNextRender(() => {
+      const [selectionArgs] = getFireArgs().filter(arg => arg[0] === Constants.events.SELECTION_CHANGE);
+      st.ok(selectionArgs, 'should have fired a selectionchange event');
+
+      if (selectionArgs) {
+        const [selectedFeature] = selectionArgs[1].features;
+        st.ok(selectedFeature && selectedFeature.id === lineId, 'should have selected the provided line');
+
+        const [selectedPoint] = selectionArgs[1].points;
+        st.deepEqual(selectedPoint.geometry.coordinates, selectedFeature.geometry.coordinates[0], 'should have selected the coordinate under the path');
+      }
+
+      cleanUp(() => st.end());
+    });
+  });
+
   document.body.removeChild(mapContainer);
   t.end();
 });


### PR DESCRIPTION
The `draw.selectionchange` event fired when moving into direct_select mode with
a `coordPath` will now correctly include the point. Before, the event was
fired with the correct selected feature, but lacking in the point.

This bug was caused because of a misordered selection call: First the
coordinates were selected, and only then the feature. During the feature
selection, the store's `refreshSelectedCoordinates` function was called
*before* the feature was actually selected, meaning the previously
coordinates were effectively removed.