### PR TITLE
Fire a selectionchange event on midpoint click

### DIFF
--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -61,6 +61,9 @@ DirectSelect.onMidpoint = function(state, e) {
   state.feature.addCoordinate(about.coord_path, about.lng, about.lat);
   this.fireUpdate();
   state.selectedCoordPaths = [about.coord_path];
+
+  const selectedCoordinates = this.pathsToCoordinates(state.featureId, state.selectedCoordPaths);
+  this.setSelectedCoordinates(selectedCoordinates);
 };
 
 DirectSelect.pathsToCoordinates = function(featureId, paths) {

--- a/test/interaction_events.test.js
+++ b/test/interaction_events.test.js
@@ -373,8 +373,20 @@ function runTests() {
         action: 'change_coordinates',
         features: [lineD]
       });
+      firedWith(t, 'draw.selectionchange', {
+        points: [{
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Point',
+            coordinates: [41, 21]
+          }
+        }],
+        features: [lineD]
+      });
       t.deepEqual(flushDrawEvents(), [
-        'draw.update'
+        'draw.update',
+        'draw.selectionchange'
       ], 'no unexpected draw events');
       t.end();
     });
@@ -677,8 +689,20 @@ function runTests() {
         action: 'change_coordinates',
         features: [polygonD]
       });
+      firedWith(t, 'draw.selectionchange', {
+        points: [{
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Point',
+            coordinates: [25, 10]
+          }
+        }],
+        features: [polygonD]
+      });
       t.deepEqual(flushDrawEvents(), [
-        'draw.update'
+        'draw.update',
+        'draw.selectionchange'
       ], 'no unexpected draw events');
       t.end();
     });


### PR DESCRIPTION
When clicking on a feature's midpoint during direct_select mode, a
`selectionchange` event will now be fired with the selected midpoint as
the event's point.