### PR TITLE
fix documentation for this.setSelectedCoordinates

### DIFF
--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -258,7 +258,7 @@ Sets Draw's internal selected coordinate state
 
 **Parameters**
 
--   `coords` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** a array of {coord_path: 'string', featureId: 'string'}
+-   `coords` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** a array of {coord_path: 'string', feature_id: 'string'}
 
 ### this.getSelected
 


### PR DESCRIPTION
- coords should be an array of `{feature_id: 'string', coord_path: 'string'}` as per https://github.com/mapbox/mapbox-gl-draw/blob/5b2280817c901d93b05c937a7bdb2efb8afefe0c/src/modes/mode_interface_accessors.js#L33, not `{coord_path: 'string', feature_id: 'string'}`