### PR TITLE
allow to dynamically update the drawing controls

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -192,5 +192,11 @@ module.exports = function(ctx, api) {
     return api;
   };
 
+  api.setControls = function(controls) {
+    ctx.options.controls = controls;
+    ctx.ui.removeButtons();
+    ctx.ui.addButtons();
+  };
+
   return api;
 };

--- a/src/setup.js
+++ b/src/setup.js
@@ -6,7 +6,7 @@ const xtend = require('xtend');
 
 module.exports = function(ctx) {
 
-  let controlContainer = null;
+
   let mapLoadedInterval = null;
 
   const setup = {
@@ -24,8 +24,8 @@ module.exports = function(ctx) {
       ctx.container = null;
       ctx.store = null;
 
-      if (controlContainer && controlContainer.parentNode) controlContainer.parentNode.removeChild(controlContainer);
-      controlContainer = null;
+      if (ctx.controlContainer && ctx.controlContainer.parentNode) ctx.controlContainer.parentNode.removeChild(ctx.controlContainer);
+      ctx.controlContainer = null;
 
       return this;
     },
@@ -59,7 +59,7 @@ module.exports = function(ctx) {
       ctx.store = new Store(ctx);
 
 
-      controlContainer = ctx.ui.addButtons();
+      ctx.controlContainer = ctx.ui.addButtons();
 
       if (ctx.options.boxSelect) {
         map.boxZoom.disable();
@@ -77,7 +77,7 @@ module.exports = function(ctx) {
       }
 
       ctx.events.start();
-      return controlContainer;
+      return ctx.controlContainer;
     },
     addLayers: function() {
       // drawn features style

--- a/src/ui.js
+++ b/src/ui.js
@@ -100,7 +100,7 @@ module.exports = function(ctx) {
 
   function addButtons() {
     const controls = ctx.options.controls;
-    const controlGroup = document.createElement('div');
+    const controlGroup = ctx.controlContainer || document.createElement('div');
     controlGroup.className = `${Constants.classes.CONTROL_GROUP} ${Constants.classes.CONTROL_BASE}`;
 
     if (!controls) return controlGroup;


### PR DESCRIPTION
Exposes a new method called `setControls` to dynamically toggle the
drawing controls

Example usage
```javascript
 const drawControl = new MapboxDraw({
            displayControlsDefault: false,
            controls: {
                polygon: true,
                trash: true,
            },
        });
// add the control to the map
map.addControl(drawControl, 'bottom-right');

// now show only the trash 
drawControl.setControls({trash: true})

```
This is my first PR to this project and not sure if I missing some necessary step. I would appreciate any help to get this merged as it is a very handy feature.


fixes #824