### PR TITLE
change marker for drag_circle mode

### DIFF
--- a/src/lib/get_features_and_set_cursor.js
+++ b/src/lib/get_features_and_set_cursor.js
@@ -14,6 +14,9 @@ module.exports = function getFeatureAtAndSetCursors(event, ctx) {
   if (ctx.events.currentModeName().indexOf('draw') !== -1) {
     classes.mouse = Constants.cursors.ADD;
   }
+  if (ctx.events.currentModeName().indexOf('drag_circle') !== -1) {
+    classes.mouse = Constants.cursors.ADD;
+  }
 
   ctx.ui.queueMapClasses(classes);
   ctx.ui.updateMapClasses();


### PR DESCRIPTION
With reference to https://github.com/iamanvesh/mapbox-gl-draw-circle
There are two modes `draw_circle` and `drag_circle`.
So the marker for draw_circle is set to `ADD` on mouse move, hence the cursor is shown accordingly.
But there's no such thing for `drag_circle` mode.
Hence adding the condition for the `drag_circle` mode so that the cursor is set accordingly.
