### PR TITLE
Skip rerenders for mousemove handlers when in selection modes

### DIFF
--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -37,8 +37,10 @@ const ModeHandler = function(mode, DrawContext) {
     while (iHandle--) {
       const handle = handles[iHandle];
       if (handle.selector(event)) {
-        handle.fn.call(ctx, event);
-        DrawContext.store.render();
+        const skipRender = handle.fn.call(ctx, event);
+        if (!skipRender) {
+          DrawContext.store.render();
+        }
         DrawContext.ui.updateMapClasses();
 
         // ensure an event is only handled once

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -188,11 +188,17 @@ DirectSelect.onMouseMove = function(state, e) {
   else if (onVertex && !noCoords) this.updateUIClasses({ mouse: Constants.cursors.MOVE });
   else this.updateUIClasses({ mouse: Constants.cursors.NONE });
   this.stopDragging(state);
+
+  // Skip render
+  return true;
 };
 
 DirectSelect.onMouseOut = function(state) {
   // As soon as you mouse leaves the canvas, update the feature
   if (state.dragMoving) this.fireUpdate();
+
+  // Skip render
+  return true;
 };
 
 DirectSelect.onTouchStart = DirectSelect.onMouseDown = function(state, e) {

--- a/src/modes/object_to_mode.js
+++ b/src/modes/object_to_mode.js
@@ -29,9 +29,7 @@ export default function(modeObject) {
     }, new ModeInterface(ctx));
 
     function wrapper(eh) {
-      return function(e) {
-        mode[eh](state, e);
-      };
+      return e => mode[eh](state, e);
     }
 
     return {

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -103,12 +103,18 @@ SimpleSelect.onMouseMove = function(state) {
   // then move the mouse back over the canvas --- we don't allow the
   // interaction to continue then, but we do let it continue if you held
   // the mouse button that whole time
-  return this.stopExtendedInteractions(state);
+  this.stopExtendedInteractions(state);
+
+  // Skip render
+  return true;
 };
 
 SimpleSelect.onMouseOut = function(state) {
   // As soon as you mouse leaves the canvas, update the feature
   if (state.dragMoving) return this.fireUpdate();
+
+  // Skip render
+  return true;
 };
 
 SimpleSelect.onTap = SimpleSelect.onClick = function(state, e) {


### PR DESCRIPTION
Reduces CPU usage and fixes https://github.com/mapbox/mapbox-gl-draw/issues/760

CPU usage is still high when moving the mouse, but the remaining CPU usage is in queryRendereredFeatures which is used to determine the shape of the mouse pointer.