### PR TITLE
Remove condition preventing vertex removal

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -129,7 +129,7 @@ module.exports = function(ctx) {
   events.keydown = function(event) {
     if ((event.srcElement || event.target).classList[0] !== 'mapboxgl-canvas') return; // we only handle events on the map
 
-    if ((event.keyCode === 8 || event.keyCode === 46) && ctx.options.controls.trash) {
+    if (event.keyCode === 8 || event.keyCode === 46) {
       event.preventDefault();
       currentMode.trash();
     } else if (isKeyModeValid(event.keyCode)) {


### PR DESCRIPTION
Removing a condition that checks if the trash button is wanted in the UI. The vertex removal on 'keydown' should not be related with the button rendering or not