### PR TITLE
Remove unused start-server script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "prepublish": "run-s build build-min",
     "watch": "rollup -c --watch",
     "watch-bench": "rollup -c bench/rollup.config.js --watch",
-    "start-server": "st --no-cache -H 0.0.0.0 --port 9967 --index index.html .",
-    "start": "run-p build-token watch watch-bench start-server"
+    "start": "run-p build-token watch watch-bench"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm attempting to copy the development environment set up for this project in another mapbox-gl plugin (mapbox-gl-accessibility), and I noticed this script (`start-server`) doesn't seem to do anything.
