### PR TITLE
Don't call onDrag when multiple fingers are touching the map

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -101,7 +101,10 @@ export default function(ctx) {
     }
 
     currentMode.touchmove(event);
-    return events.touchdrag(event);
+
+    if (event.points.length === 1) {
+      events.touchdrag(event);
+    }
   };
 
   events.touchend = function(event) {


### PR DESCRIPTION
Calling onDrag when multiple fingers are touching the map causes a delay
when you start pinch zooming. This is because the pinch is interpreted
as a tap in the beginning, which causes stopPropagation to be called.

I think dragging is an action you only do with one finger, so therefore
I think not calling onDrag is the correct solution to this.

I'm not sure how to test this, as I haven't figured out how to check if events are called. Are there any existing tests doing such checks?

Fixes #962