### PR TITLE
Export library methods for external custom modes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,16 @@ import runSetup from './src/setup';
 import setupOptions from './src/options';
 import setupAPI from './src/api';
 import * as Constants from './src/constants';
+import * as CommonSelectors from './src/lib/common_selectors';
+import constrainFeatureMovement from './src/lib/constrain_feature_movement';
+import createSupplementaryPoints from './src/lib/create_supplementary_points';
+import createVertex from './src/lib/create_vertex';
+import doubleClickZoom from './src/lib/double_click_zoom';
+import featuresAt from './src/lib/features_at';
+import isEventAtCoordinates from './src/lib/is_event_at_coordinates';
+import mouseEventPoint from './src/lib/mouse_event_point';
+import moveFeatures from './src/lib/move_features';
+import StringSet from './src/lib/string_set';
 
 const setupDraw = function(options, api) {
   options = setupOptions(options);
@@ -29,5 +39,19 @@ function MapboxDraw(options) {
 
 import modes from './src/modes/index';
 MapboxDraw.modes = modes;
+
+export {
+  Constants,
+  CommonSelectors,
+  constrainFeatureMovement,
+  createSupplementaryPoints,
+  createVertex,
+  doubleClickZoom,
+  featuresAt,
+  isEventAtCoordinates,
+  mouseEventPoint,
+  moveFeatures,
+  StringSet
+};
 
 export default MapboxDraw;


### PR DESCRIPTION
These are all the library methods that all the modes use. Exporting them
makes it possible for others to write custom modes which provides the
same functionality.

Fixes #786