### PR TITLE
Allow deleting the whole feature from direct_select

### DIFF
--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -164,18 +164,23 @@ DirectSelect.toDisplayFeatures = function(state, geojson, push) {
 };
 
 DirectSelect.onTrash = function(state) {
-  // Uses number-aware sorting to make sure '9' < '10'. Comparison is reversed because we want them
-  // in reverse order so that we can remove by index safely.
-  state.selectedCoordPaths
-    .sort((a, b) => b.localeCompare(a, 'en', { numeric: true }))
-    .forEach(id => state.feature.removeCoordinate(id));
-  this.fireUpdate();
-  state.selectedCoordPaths = [];
-  this.clearSelectedCoordinates();
-  this.fireActionable(state);
-  if (state.feature.isValid() === false) {
+  if (state.selectedCoordPaths.length === 0) {
     this.deleteFeature([state.featureId]);
     this.changeMode(Constants.modes.SIMPLE_SELECT, {});
+  } else {
+    // Uses number-aware sorting to make sure '9' < '10'. Comparison is reversed because we want them
+    // in reverse order so that we can remove by index safely.
+    state.selectedCoordPaths
+      .sort((a, b) => b.localeCompare(a, 'en', { numeric: true }))
+      .forEach(id => state.feature.removeCoordinate(id));
+    this.fireUpdate();
+    state.selectedCoordPaths = [];
+    this.clearSelectedCoordinates();
+    this.fireActionable(state);
+    if (state.feature.isValid() === false) {
+      this.deleteFeature([state.featureId]);
+      this.changeMode(Constants.modes.SIMPLE_SELECT, {});
+    }
   }
 };
 

--- a/test/direct_select.test.js
+++ b/test/direct_select.test.js
@@ -148,6 +148,19 @@ test('direct_select', (t) => {
     });
   });
 
+  t.test('direct_select - trashing with no vertices selected should delete the feature', (st) => {
+    const ids = Draw.add(getGeoJSON('polygon'));
+    Draw.changeMode(Constants.modes.DIRECT_SELECT, {
+      featureId: ids[0]
+    });
+    afterNextRender(() => {
+      Draw.trash();
+      const afterTrash = Draw.get(ids[0]);
+      st.equal(afterTrash, undefined);
+      cleanUp(() => st.end());
+    });
+  });
+
   t.test('direct_select - a click on a vertex and than dragging the map shouldn\'t drag the vertex', (st) => {
     const ids = Draw.add(getGeoJSON('polygon'));
     Draw.changeMode(Constants.modes.DIRECT_SELECT, {


### PR DESCRIPTION
When no vertices are selected, trash deletes the whole feature.