### PR TITLE
Include shims for the fs and path dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "opener": "^1.4.1",
     "rollup": "^1.27.13",
     "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-terser": "^5.1.3",
     "sinon": "^7.5.0",
     "st": "^2.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import buble from '@rollup/plugin-buble';
 import {terser} from 'rollup-plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import shim from 'rollup-plugin-shim';
 
 export default {
   input: ['index.js'],
@@ -18,15 +19,15 @@ export default {
     indent: false
   },
   treeshake: true,
-  external: [
-    // geojsonlint-lines has a main function that requires the path and fs module.
-    // We never call it.
-    'fs',
-    'path'
-  ],
   plugins: [
     replace({
       'process.env.NODE_ENV': "'browser'"
+    }),
+    shim({
+      // geojsonlint-lines has a main function that requires the fs and path modules.
+      // We never call it.
+      fs: 'export default {}',
+      path: 'export default {}',
     }),
     buble({transforms: {dangerousForOf: true}, objectAssign: "Object.assign"}),
     minified ? terser() : false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5197,6 +5197,11 @@ rollup-plugin-commonjs@^10.1.0:
     resolve "^1.11.0"
     rollup-pluginutils "^2.8.1"
 
+rollup-plugin-shim@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-shim/-/rollup-plugin-shim-1.0.0.tgz#b00f5cb44cdae81358c5342fe82fa71a1602b56b"
+  integrity sha512-rZqFD43y4U9nSqVq3iyWBiDwmBQJY8Txi04yI9jTKD3xcl7CbFjh1qRpQshUB3sONLubDzm7vJiwB+1MEGv67w==
+
 rollup-plugin-terser@^5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.1.3.tgz#5f4c4603b12b4f8d093f4b6f31c9aa5eba98a223"


### PR DESCRIPTION
Including fs and path in externals is not sufficient when this is used
in a browser. That will just make rollup leave the requires calls, and
when you try to include this library in a webpack project webpack will
complain that fs is missing.

By providing shims for fs and path, those will be used instead of
require calls, so that fixes the issue. Since no code paths in this
library triggers the code that requires fs or path it's safe to just
shim them out with an empty object.

Fixes #970