### PR TITLE
Adds insertBeforeLayerId option

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -36,6 +36,7 @@ All of the following options are optional.
 - `modes`, Object: over ride the default modes with your own. `MapboxDraw.modes` can be used to see the default values. More information on custom modes [can be found here](https://github.com/mapbox/mapbox-gl-draw/blob/master/docs/MODES.md).
 - `defaultMode`, String (default: `'simple_select'`): the mode (from `modes`) that user will first land in.
 - `userProperties`, boolean (default: `false`): properties of a feature will also be available for styling and prefixed with `user_`, e.g., `['==', 'user_custom_label', 'Example']`
+- `insertBeforeLayerId`, string (default: `undefined`): The ID of an existing layer to insert MapboxDraw draw layers before. If this argument is not specified, layers will be appended to the end of the layers array - [more here](https://docs.mapbox.com/mapbox-gl-js/api/#map#addlayer). 
 
 ## Modes
 

--- a/src/options.js
+++ b/src/options.js
@@ -15,7 +15,8 @@ const defaultOptions = {
   styles,
   modes,
   controls: {},
-  userProperties: false
+  userProperties: false,
+  insertBeforeLayerId: undefined,
 };
 
 const showControls = {

--- a/src/setup.js
+++ b/src/setup.js
@@ -100,7 +100,7 @@ export default function(ctx) {
       });
 
       ctx.options.styles.forEach((style) => {
-        ctx.map.addLayer(style);
+        ctx.map.addLayer(style, ctx.options.insertBeforeLayerId);
       });
 
       ctx.store.setDirty(true);

--- a/test/layers_insert.test.js
+++ b/test/layers_insert.test.js
@@ -1,0 +1,32 @@
+/* eslint no-shadow:[0] */
+import test from "tape";
+import MapboxDraw from '../';
+import createMap from "./utils/create_map";
+import spy from "sinon/lib/sinon/spy";
+
+test("Layers insert test", (t) => {
+  t.test("add map layer before insertBeforeLayerId", (t) => {
+    const layerId = "test";
+    const map = createMap();
+    const addLayerSpy = spy(map, "addLayer");
+    const opts = {
+      insertBeforeLayerId: layerId
+    };
+    const Draw = new MapboxDraw(opts);
+    map.addControl(Draw);
+
+    t.equal(addLayerSpy.firstCall.lastArg, layerId, "should match layerId");
+    t.end();
+  });
+
+  t.test("add map layer at the end", (t) => {
+    const map = createMap();
+    const addLayerSpy = spy(map, "addLayer");
+    const opts = {};
+    const Draw = new MapboxDraw(opts);
+    map.addControl(Draw);
+
+    t.equal(addLayerSpy.firstCall.lastArg, undefined, "should not be defined");
+    t.end();
+  });
+});

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -25,7 +25,8 @@ test('Options test', (t) => {
         trash: true,
         combine_features: true,
         uncombine_features: true
-      }
+      },
+      insertBeforeLayerId: undefined
     };
     t.deepEquals(defaultOptions, Draw.options);
     t.deepEquals(styleWithSourcesFixture, Draw.options.styles);
@@ -52,7 +53,8 @@ test('Options test', (t) => {
         trash: true,
         combine_features: true,
         uncombine_features: true
-      }
+      },
+      insertBeforeLayerId: undefined
     };
 
     t.deepEquals(defaultOptions, Draw.options);
@@ -79,7 +81,8 @@ test('Options test', (t) => {
         trash: false,
         combine_features: false,
         uncombine_features: false
-      }
+      },
+      insertBeforeLayerId: undefined
     };
     t.deepEquals(defaultOptions, Draw.options);
     t.end();
@@ -105,7 +108,8 @@ test('Options test', (t) => {
         trash: false,
         combine_features: false,
         uncombine_features: false
-      }
+      },
+      insertBeforeLayerId: undefined
     };
 
     t.deepEquals(defaultOptions, Draw.options);
@@ -132,7 +136,8 @@ test('Options test', (t) => {
         trash: true,
         combine_features: true,
         uncombine_features: true
-      }
+      },
+      insertBeforeLayerId: undefined
     };
 
     t.deepEquals(defaultOptions, Draw.options);
@@ -159,10 +164,38 @@ test('Options test', (t) => {
         trash: true,
         combine_features: true,
         uncombine_features: true
-      }
+      },
+      insertBeforeLayerId: undefined
     };
     t.deepEquals(defaultOptions, Draw.options);
     t.deepEquals(styleWithSourcesFixture, Draw.options.styles);
+    t.end();
+  });
+
+  t.test('disable set insertBeforeLayerId', (t) => {
+    const Draw = new MapboxDraw({ insertBeforeLayerId: 'layerId' });
+    const defaultOptions = {
+      defaultMode: 'simple_select',
+      modes,
+      touchEnabled: true,
+      keybindings: true,
+      clickBuffer: 2,
+      touchBuffer: 25,
+      displayControlsDefault: true,
+      boxSelect: true,
+      userProperties: false,
+      styles: Draw.options.styles,
+      controls: {
+        point: true,
+        line_string: true,
+        polygon: true,
+        trash: true,
+        combine_features: true,
+        uncombine_features: true
+      },
+      insertBeforeLayerId: 'layerId'
+    };
+    t.deepEquals(defaultOptions, Draw.options);
     t.end();
   });
 


### PR DESCRIPTION
Using this option user can specify id of the layer before all MapboxDraw layers should be inserted.

Happy to improve naming/tests if needed.