### PR TITLE
Add link to geodesic modes

### DIFF
--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -75,6 +75,7 @@ _please feel free to add your own modes to this list via a PR_
 -   [Assisted Rectangle Mode](https://github.com/geostarters/mapbox-gl-draw-assisted-rectangle-mode)
 -   [Rotate/Scale Rectangle Mode](https://github.com/drykovanov/mapbox-gl-draw-rotate-scale-rect-mode)
 -   [Rectangle Restrict Area Mode](https://github.com/dqunbp/mapbox-gl-draw-rectangle-restrict-area): Drawing a rectangle with a limited area
+-   [Geodesic Modes](https://github.com/zakjan/mapbox-gl-draw-geodesic): Draw geodesic lines, polygons and circles
 
 ## Life Cycle Functions
 


### PR DESCRIPTION
I have created geodesic modes plugin. Most of the modes simply inherit from the original MapboxDraw modes, and wrap `toDisplayFeatures` function with geodesic calculation.

```
const DrawLineString = MapboxDraw.modes[Constants.modes.DRAW_LINE_STRING];

const DrawLineStringGeodesic = { ...DrawLineString };

DrawLineStringGeodesic.toDisplayFeatures = function(state, geojson, display) {
  const displayGeodesic = (geojson) => {
    const geodesicGeojson = createGeodesicFeature(geojson, { ctx: this._ctx });
    geodesicGeojson.forEach(display);
  };

  DrawLineString.toDisplayFeatures.call(this, state, geojson, displayGeodesic);
};
```

There is also a static mode which can be used to render geodesic map features without using the drawing capabilities. It is useful because geodesic calculations are isolated inside the plugin, keeping user code abstracted away from the calculations.

Related to https://github.com/mapbox/mapbox-gl-js/issues/3544