### PR TITLE
Update README.md with changes from v1.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,16 @@ Adds support for drawing and editing features on [mapbox-gl.js](https://www.mapb
 npm install @mapbox/mapbox-gl-draw
 ```
 
-Draw ships with CSS, make sure you include it in your build.  
+Draw ships with CSS, make sure you include it in your build.
+
 **When using modules**
  ```js
-require('@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css')
-// or
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css'
  ```
 
 **When using CDN**
 ```html
-<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.0.9/mapbox-gl-draw.css' type='text/css' />
+<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.2.0/mapbox-gl-draw.css' type='text/css' />
 ```
 
 ### Usage in your application
@@ -32,14 +31,14 @@ import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css'
 **When using modules**
 
 ```js
-var mapboxgl = require('mapbox-gl');
-var MapboxDraw = require('@mapbox/mapbox-gl-draw');
+import mapboxgl from 'mapbox-gl';
+import MapboxDraw from "@mapbox/mapbox-gl-draw";
 ```
 
 **When using a CDN**
 
 ```html
-<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.0.9/mapbox-gl-draw.js'></script>
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.2.0/mapbox-gl-draw.js'></script>
 ```
 
 **Example setup**


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-draw/issues/997.

Also updates referenced CDNs from `v1.0.9` to `v1.2.0`.