### PR TITLE
Add typescript install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ npm install @mapbox/mapbox-gl-draw
 
 Draw ships with CSS, make sure you include it in your build.
 
+
+### Typescript 
+
+Typescript definition files are available as part of the [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mapbox__mapbox-gl-draw) package. 
+
+```
+npm install @types/mapbox__mapbox-gl-draw
+```
+
 **When using modules**
  ```js
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css'


### PR DESCRIPTION
The PR adding TS definition files just got merged to definitely typed: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mapbox__mapbox-gl-draw/index.d.ts

Thir PR updates the README.md file to better explain what typescript users should do to install the ts definition files.

related issues: https://github.com/mapbox/mapbox-gl-draw/issues/842