### PR TITLE
fix: Change how events.keydown checks classList for mapboxgl-canvas 

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -127,7 +127,9 @@ export default function(ctx) {
   const isKeyModeValid = code => !(code === 8 || code === 46 || (code >= 48 && code <= 57));
 
   events.keydown = function(event) {
-    if ((event.srcElement || event.target).classList[0] !== 'mapboxgl-canvas') return; // we only handle events on the map
+    const classList = (event.srcElement || event.target).classList;
+    const isAMapboxCanvas = Array.isArray(classList) ? classList.includes('mapboxgl-canvas') : classList.contains('mapboxgl-canvas');
+    if (!isAMapboxCanvas) return; // we only handle events on the map
 
     if ((event.keyCode === 8 || event.keyCode === 46) && ctx.options.controls.trash) {
       event.preventDefault();


### PR DESCRIPTION
### Overview
- Originally `events.keydown` only checked the first value in the `classList` to see that it matches `mapboxgl-canvas`
- Updated so that it checks the full `classList` for the value `mapboxgl-canvas`
  - This enables usage with a classList that starts with `maplibregl-canvas`  for instance
- **NOTE - Contains vs Includes**
  - `DOMTokenList` only supports `contains`
  - In our tests we create synthetic events with an array for a classList which only supports `includes`
  - Couldn't create a `DOMTokenList` without creating an element so went with this approach