### PR TITLE
chore: export constants and lib through MapboxDraw

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import runSetup from './src/setup';
 import setupOptions from './src/options';
 import setupAPI from './src/api';
 import * as Constants from './src/constants';
+import * as lib from './src/lib';
 
 const setupDraw = function(options, api) {
   options = setupOptions(options);
@@ -29,5 +30,7 @@ function MapboxDraw(options) {
 
 import modes from './src/modes/index';
 MapboxDraw.modes = modes;
+MapboxDraw.constants = Constants;
+MapboxDraw.lib = lib;
 
 export default MapboxDraw;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,43 @@
+import * as CommonSelectors from "./common_selectors";
+import constrainFeatureMovement from "./constrain_feature_movement";
+import createMidPoint from "./create_midpoint";
+import createSupplementaryPoints from "./create_supplementary_points";
+import createVertex from "./create_vertex";
+import doubleClickZoom from "./double_click_zoom";
+import euclideanDistance from "./euclidean_distance";
+import featuresAt from "./features_at";
+import getFeatureAtAndSetCursors from "./get_features_and_set_cursor";
+import isClick from "./is_click";
+import isEventAtCoordinates from "./is_event_at_coordinates";
+import isTap from "./is_tap";
+import mapEventToBoundingBox from "./map_event_to_bounding_box";
+import ModeHandler from "./mode_handler";
+import moveFeatures from "./move_features";
+import sortFeatures from "./sort_features";
+import StringSet from "./string_set";
+import stringSetsAreEqual from "./string_sets_are_equal";
+import theme from "./theme";
+import toDenseArray from "./to_dense_array";
+
+export {
+  CommonSelectors,
+  constrainFeatureMovement,
+  createMidPoint,
+  createSupplementaryPoints,
+  createVertex,
+  doubleClickZoom,
+  euclideanDistance,
+  featuresAt,
+  getFeatureAtAndSetCursors,
+  isClick,
+  isEventAtCoordinates,
+  isTap,
+  mapEventToBoundingBox,
+  ModeHandler,
+  moveFeatures,
+  sortFeatures,
+  stringSetsAreEqual,
+  StringSet,
+  theme,
+  toDenseArray,
+};


### PR DESCRIPTION
### Overview
- Saw there was an issue for exposing API's to make it easier to write custom draw modes - https://github.com/mapbox/mapbox-gl-draw/issues/1056
  - Experiencing a similar issue here - https://github.com/aws-amplify/maplibre-gl-draw-circle
- Added everything in `Constants` and `Lib` to the `MapboxDraw` default export
  -  Considered making them separate named exports from the default but wanted to keep it in line with `modes` which is also added directly onto the `MapboxDraw` object
   