### PR TITLE
update css for control buttons

### DIFF
--- a/dist/mapbox-gl-draw.css
+++ b/dist/mapbox-gl-draw.css
@@ -10,24 +10,17 @@
   margin-right:0;
   border-radius:4px 0 0 4px;
 }
-.mapbox-gl-draw_ctrl-draw {
-  background-color:rgba(0,0,0,0.75);
-  border-color:rgba(0,0,0,0.9);
-}
-.mapbox-gl-draw_ctrl-draw > button {
+
+.mapbox-gl-draw_ctrl-draw-btn {
   border-color:rgba(0,0,0,0.9);
   color:rgba(255,255,255,0.5);
   width:30px;
   height:30px;
 }
-.mapbox-gl-draw_ctrl-draw > button:hover {
-  background-color:rgba(0,0,0,0.85);
-  color:rgba(255,255,255,0.75);
-}
-.mapbox-gl-draw_ctrl-draw > button.active,
-.mapbox-gl-draw_ctrl-draw > button.active:hover {
-  background-color:rgba(0,0,0,0.95);
-  color:#fff;
+
+.mapbox-gl-draw_ctrl-draw-btn.active,
+.mapbox-gl-draw_ctrl-draw-btn.active:hover {
+  background-color:rgb(0 0 0/5%);
 }
 .mapbox-gl-draw_ctrl-draw-btn {
   background-repeat: no-repeat;


### PR DESCRIPTION
There were several CSS classes no longer being applied because their parent `.mapbox-gl-draw_ctrl-draw` never exists.  Instead of `.mapbox-gl-draw_ctrl-draw > button` to style buttons in the controls, the css is changed to just use `.mapbox-gl-draw_ctrl-draw-btn`. 

This restores a different style for when a button is active (this PR sets the active background color to be the same gray used when hovering a mapbox control button.)

Closes #1124
<img width="453" alt="Fullscreen_10_13_22__11_57_AM" src="https://user-images.githubusercontent.com/1833820/195646546-121b3348-6482-4dd3-9520-f6fea4283c0e.png">


