### PR TITLE
Keep midpoint on the line

### DIFF
--- a/src/lib/create_midpoint.js
+++ b/src/lib/create_midpoint.js
@@ -1,4 +1,5 @@
 import * as Constants from '../constants';
+import { mercatorYfromLat, latFromMercatorY } from 'mapbox-gl/geo/mercator_coordinate'
 
 export default function(parent, startVertex, endVertex) {
   const startCoord = startVertex.geometry.coordinates;
@@ -15,7 +16,7 @@ export default function(parent, startVertex, endVertex) {
 
   const mid = {
     lng: (startCoord[0] + endCoord[0]) / 2,
-    lat: (startCoord[1] + endCoord[1]) / 2
+    lat: latFromMercatorY((mercatorYfromLat(startCoord[1]) + mercatorYfromLat(endCoord[1])) / 2)
   };
 
   return {


### PR DESCRIPTION
Drawing with the average of the LngLat of the two endpoints, the middle points were off from the line. By project/unproject the Mercator latitudes to and from screen space, the screen location for midpoints would be fixed to the line.