### PR TITLE
Adding sorting rank value for MultiLineString

### DIFF
--- a/src/lib/sort_features.js
+++ b/src/lib/sort_features.js
@@ -4,6 +4,7 @@ import * as Constants from '../constants';
 const FEATURE_SORT_RANKS = {
   Point: 0,
   LineString: 1,
+  MultiLineString: 1,
   Polygon: 2
 };
 


### PR DESCRIPTION
As simple_select sometimes renders lines as `MultiLineString` geometry, `sortFeatures()` should handle this type or midpoint clicking would fail.

This could fix issue #1117.