### PR TITLE
fixes  #1019 "Unable to preventDefault inside passive event" on chrome mobile error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "rollup -c",
     "build-min": "rollup -c --environment MINIFY:true",
     "prepublishOnly": "run-s build build-min",
+    "prepare": "run-s build build-min",
     "watch": "rollup -c --watch",
     "watch-bench": "rollup -c bench/rollup.config.js --watch",
     "start-server": "st --no-cache -H 0.0.0.0 --port 9967 --index index.html .",

--- a/src/events.js
+++ b/src/events.js
@@ -78,9 +78,6 @@ export default function(ctx) {
   };
 
   events.touchstart = function(event) {
-    // Prevent emulated mouse events because we will fully handle the touch here.
-    // This does not stop the touch events from propogating to mapbox though.
-    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -95,7 +92,6 @@ export default function(ctx) {
   };
 
   events.touchmove = function(event) {
-    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -105,7 +101,6 @@ export default function(ctx) {
   };
 
   events.touchend = function(event) {
-    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }


### PR DESCRIPTION
1) since Chrome 56 all touch event listeners are passive by default
further information -> https://chromestatus.com/feature/5093566007214080

2) added prepare script: provides possibility for others to use (this bugfix) forks of mapbox-draw in their projects via e.g. 
`npm install theirGithubUsername/mapbox-gl-draw`