### PR TITLE
fixes #1019 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "rollup -c",
     "build-min": "rollup -c --environment MINIFY:true",
     "prepublishOnly": "run-s build build-min",
+    "prepare": "run-s build build-min",
     "watch": "rollup -c --watch",
     "watch-bench": "rollup -c bench/rollup.config.js --watch",
     "start-server": "st --no-cache -H 0.0.0.0 --port 9967 --index index.html .",

--- a/src/events.js
+++ b/src/events.js
@@ -78,9 +78,6 @@ export default function(ctx) {
   };
 
   events.touchstart = function(event) {
-    // Prevent emulated mouse events because we will fully handle the touch here.
-    // This does not stop the touch events from propogating to mapbox though.
-    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -95,7 +92,6 @@ export default function(ctx) {
   };
 
   events.touchmove = function(event) {
-    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -105,7 +101,6 @@ export default function(ctx) {
   };
 
   events.touchend = function(event) {
-    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }

--- a/src/events.js
+++ b/src/events.js
@@ -78,6 +78,9 @@ export default function(ctx) {
   };
 
   events.touchstart = function(event) {
+    if (!navigator.userAgent.match(/chrome|chromium|crios/i)) {
+      event.originalEvent.preventDefault();
+    }
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -92,6 +95,9 @@ export default function(ctx) {
   };
 
   events.touchmove = function(event) {
+    if (!navigator.userAgent.match(/chrome|chromium|crios/i)) {
+      event.originalEvent.preventDefault();
+    }
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -101,6 +107,9 @@ export default function(ctx) {
   };
 
   events.touchend = function(event) {
+    if (!navigator.userAgent.match(/chrome|chromium|crios/i)) {
+      event.originalEvent.preventDefault();
+    }
     if (!ctx.options.touchEnabled) {
       return;
     }

--- a/src/events.js
+++ b/src/events.js
@@ -78,9 +78,6 @@ export default function(ctx) {
   };
 
   events.touchstart = function(event) {
-    if (!navigator.userAgent.match(/chrome|chromium|crios/i)) {
-      event.originalEvent.preventDefault();
-    }
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -95,9 +92,6 @@ export default function(ctx) {
   };
 
   events.touchmove = function(event) {
-    if (!navigator.userAgent.match(/chrome|chromium|crios/i)) {
-      event.originalEvent.preventDefault();
-    }
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -107,9 +101,6 @@ export default function(ctx) {
   };
 
   events.touchend = function(event) {
-    if (!navigator.userAgent.match(/chrome|chromium|crios/i)) {
-      event.originalEvent.preventDefault();
-    }
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -228,9 +219,9 @@ export default function(ctx) {
       ctx.map.on('mouseup', events.mouseup);
       ctx.map.on('data', events.data);
 
-      ctx.map.on('touchmove', events.touchmove);
-      ctx.map.on('touchstart', events.touchstart);
-      ctx.map.on('touchend', events.touchend);
+      ctx.map.on('touchmove', events.touchmove, {passive:true});
+      ctx.map.on('touchstart', events.touchstart, {passive:true});
+      ctx.map.on('touchend', events.touchend, {passive:true});
 
       ctx.container.addEventListener('mouseout', events.mouseout);
 


### PR DESCRIPTION
fixes:
- popups not opening by click event on mobile browsers if mapbox-draw activated
- chrome mobile console error "Unable to preventDefault inside passive event listener invocation."

More information about the issue & solution:
- https://chromestatus.com/feature/5093566007214080
- https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener