### PR TITLE
Revert "Use passive event listeners instead of `preventDefault`"

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -78,6 +78,9 @@ export default function(ctx) {
   };
 
   events.touchstart = function(event) {
+    // Prevent emulated mouse events because we will fully handle the touch here.
+    // This does not stop the touch events from propogating to mapbox though.
+    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -92,6 +95,7 @@ export default function(ctx) {
   };
 
   events.touchmove = function(event) {
+    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -101,6 +105,7 @@ export default function(ctx) {
   };
 
   events.touchend = function(event) {
+    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -219,9 +224,9 @@ export default function(ctx) {
       ctx.map.on('mouseup', events.mouseup);
       ctx.map.on('data', events.data);
 
-      ctx.map.on('touchmove', events.touchmove, {passive:true});
-      ctx.map.on('touchstart', events.touchstart, {passive:true});
-      ctx.map.on('touchend', events.touchend, {passive:true});
+      ctx.map.on('touchmove', events.touchmove);
+      ctx.map.on('touchstart', events.touchstart);
+      ctx.map.on('touchend', events.touchend);
 
       ctx.container.addEventListener('mouseout', events.mouseout);
 


### PR DESCRIPTION
Hi @danielsippel,

I'm going to revert the mapbox/mapbox-gl-draw#1146 since it currently breaks the touch events as reported in https://github.com/mapbox/mapbox-gl-draw/issues/1154. I missed it during the manual testing, and we'd need to look for a different way to do it. Sorry for the inconvenience.