### PR TITLE
fix: set up events correctly when instantiating api

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -4,6 +4,7 @@ import hat from 'hat';
 import featuresAt from './lib/features_at';
 import stringSetsAreEqual from './lib/string_sets_are_equal';
 import * as Constants from './constants';
+import events from './events';
 import StringSet from './lib/string_set';
 
 import Polygon from './feature_types/polygon';
@@ -21,6 +22,7 @@ const featureTypes = {
 };
 
 export default function(ctx, api) {
+  ctx.events = events(ctx);
 
   api.modes = Constants.modes;
 


### PR DESCRIPTION
Closes #1007. Ran into this issue when trying to make an external button display active state depending on the current mode. I verified that it works locally, but am unsure about testing policy. If this needs more work, let me know in comments and I'll get on it.