### PR TITLE
Draw should not interfere with dragPan.disable()

### DIFF
--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -28,13 +28,17 @@ DirectSelect.fireActionable = function(state) {
 };
 
 DirectSelect.startDragging = function(state, e) {
+  state.initialDragPanState = this.map.dragPan.isEnabled();
+
   this.map.dragPan.disable();
   state.canDragMove = true;
   state.dragMoveLocation = e.lngLat;
 };
 
 DirectSelect.stopDragging = function(state) {
-  this.map.dragPan.enable();
+  if (state.initialDragPanState) {
+    this.map.dragPan.enable();
+  }
   state.dragMoving = false;
   state.canDragMove = false;
   state.dragMoveLocation = null;
@@ -128,7 +132,8 @@ DirectSelect.onSetup = function(opts) {
     dragMoveLocation: opts.startPos || null,
     dragMoving: false,
     canDragMove: false,
-    selectedCoordPaths: opts.coordPath ? [opts.coordPath] : []
+    selectedCoordPaths: opts.coordPath ? [opts.coordPath] : [],
+    initialDragPanState: this.map.dragPan.isEnabled()
   };
 
   this.setSelectedCoordinates(this.pathsToCoordinates(featureId, state.selectedCoordPaths));

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -36,7 +36,7 @@ DirectSelect.startDragging = function(state, e) {
 };
 
 DirectSelect.stopDragging = function(state) {
-  if (state.initialDragPanState) {
+  if (state.canDragMove && state.initialDragPanState === true) {
     this.map.dragPan.enable();
   }
   state.dragMoving = false;
@@ -133,7 +133,7 @@ DirectSelect.onSetup = function(opts) {
     dragMoving: false,
     canDragMove: false,
     selectedCoordPaths: opts.coordPath ? [opts.coordPath] : [],
-    initialDragPanState: this.map.dragPan.isEnabled()
+    desiredDragPanState: null
   };
 
   this.setSelectedCoordinates(this.pathsToCoordinates(featureId, state.selectedCoordPaths));

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -86,7 +86,7 @@ SimpleSelect.stopExtendedInteractions = function(state) {
     state.boxSelectElement = null;
   }
 
-  if (state.initialDragPanState !== false) {
+  if ((state.canDragMove || state.canBoxSelect) && state.initialDragPanState === true) {
     this.map.dragPan.enable();
   }
 

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -18,6 +18,7 @@ SimpleSelect.onSetup = function(opts) {
     canBoxSelect: false,
     dragMoving: false,
     canDragMove: false,
+    initialDragPanState: this.map.dragPan.isEnabled(),
     initiallySelectedFeatureIds: opts.featureIds || []
   };
 
@@ -85,7 +86,9 @@ SimpleSelect.stopExtendedInteractions = function(state) {
     state.boxSelectElement = null;
   }
 
-  this.map.dragPan.enable();
+  if (state.initialDragPanState !== false) {
+    this.map.dragPan.enable();
+  }
 
   state.boxSelecting = false;
   state.canBoxSelect = false;
@@ -204,6 +207,7 @@ SimpleSelect.clickOnFeature = function(state, e) {
 };
 
 SimpleSelect.onMouseDown = function(state, e) {
+  state.initialDragPanState = this.map.dragPan.isEnabled();
   if (CommonSelectors.isActiveFeature(e)) return this.startOnActiveFeature(state, e);
   if (this.drawConfig.boxSelect && CommonSelectors.isShiftMousedown(e)) return this.startBoxSelect(state, e);
 };

--- a/src/setup.js
+++ b/src/setup.js
@@ -64,10 +64,14 @@ export default function(ctx) {
 
       if (ctx.options.boxSelect) {
         map.boxZoom.disable();
+        const dragPanState = map.dragPan.isEnabled();
         // Need to toggle dragPan on and off or else first
         // dragPan disable attempt in simple_select doesn't work
         map.dragPan.disable();
         map.dragPan.enable();
+        if (!dragPanState) {
+          map.dragPan.disable();
+        }
       }
 
       if (map.loaded()) {


### PR DESCRIPTION
Fixes #654

The issue is that Draw assumes that dragPan is enabled and simply enables it without question after certain operations (when dragpan is temporarily disabled). This change would set a variable called initialDragPanState and only re-enables when it was originally enabled.