### PR TITLE
Remove preventDefault() on touchstart and touchmove events

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -101,6 +101,8 @@ export default function(ctx) {
   };
 
   events.touchend = function(event) {
+    // Prevent emulated mouse events because we will fully handle the touch here.
+    // This does not stop the touch events from propogating to mapbox though.
     event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;

--- a/src/events.js
+++ b/src/events.js
@@ -78,9 +78,6 @@ export default function(ctx) {
   };
 
   events.touchstart = function(event) {
-    // Prevent emulated mouse events because we will fully handle the touch here.
-    // This does not stop the touch events from propogating to mapbox though.
-    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -95,7 +92,6 @@ export default function(ctx) {
   };
 
   events.touchmove = function(event) {
-    event.originalEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }


### PR DESCRIPTION
Touchstart and touchmove listeners added to the document by default as passive, so that calls to preventDefault will be ignored and will create a browser error like "Unable to preventDefault inside passive event".

The difference between this solution and the previous one tring to fix that bug (https://github.com/mapbox/mapbox-gl-draw/commit/5a904720cf7405ccecfbb3957dd8c63bf04b5829) is that we leave preventDefault inside the touchend event. 

More info on: https://chromestatus.com/feature/5093566007214080 and https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#compatibility_with_mouse_events

Fixes #1019