### PR TITLE
Release v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.3
+
+* Fix for layer not found error in `featuresAt` function by @caldwellc in https://github.com/mapbox/mapbox-gl-draw/pull/1194
+* Trigger `featureChanged` on feature props change by @wyozi in https://github.com/mapbox/mapbox-gl-draw/pull/1196
+* Remove `preventDefault()` on `touchstart` and `touchmove` events by @Archetylator in https://github.com/mapbox/mapbox-gl-draw/pull/1195
+
 ## 1.4.2
 
 * Fix key event handler checks for `mapboxgl-canvas` by @neodescis in https://github.com/mapbox/mapbox-gl-draw/pull/1165

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import MapboxDraw from "@mapbox/mapbox-gl-draw";
 **When using a CDN**
 
 ```html
-<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.2/mapbox-gl-draw.js'></script>
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.3/mapbox-gl-draw.js'></script>
 ```
 
 #### CSS
@@ -42,7 +42,7 @@ import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css'
 
 **When using CDN**
 ```html
-<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.2/mapbox-gl-draw.css' type='text/css' />
+<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.3/mapbox-gl-draw.css' type='text/css' />
 ```
 
 ### Typescript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-draw",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A drawing component for Mapbox GL JS",
   "homepage": "https://github.com/mapbox/mapbox-gl-draw",
   "author": "mapbox",


### PR DESCRIPTION
* Fix for layer not found error in `featuresAt` function by @caldwellc in https://github.com/mapbox/mapbox-gl-draw/pull/1194
* Trigger `featureChanged` on feature props change by @wyozi in https://github.com/mapbox/mapbox-gl-draw/pull/1196
* Remove `preventDefault()` on `touchstart` and `touchmove` events by @Archetylator in https://github.com/mapbox/mapbox-gl-draw/pull/1195