### PR TITLE
fix: trigger featureChanged on feature props change

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -93,8 +93,9 @@ export default function(ctx, api) {
       } else {
         // If a feature of that id has already been created, and we are swapping it out ...
         const internalFeature = ctx.store.get(feature.id);
+        const originalProperties = internalFeature.properties;
         internalFeature.properties = feature.properties;
-        if (!isEqual(internalFeature.properties, feature.properties)) {
+        if (!isEqual(originalProperties, feature.properties)) {
           ctx.store.featureChanged(internalFeature.id);
         }
         if (!isEqual(internalFeature.getCoordinates(), feature.geometry.coordinates)) {


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-draw/pull/1196 intended to add a call to `featureChanged` any time a feature was `add()`ed with modified properties, however it has a bug in that the check came after assignment.

An alternative to this fix would be to move the assignment inside the `if()` body, but that could break other code that depended on referential equality after calling `add()`.

I verified the fix by hacking the demo to include a button which modified a property on a feature, and also hacked the stylesheet to render that property as a label. Code here: https://github.com/petermoz/mapbox-gl-draw/commit/132d2d2da8aff3ab0246bd9e8036725bb097e1d4

I had a look at adding tests but couldn't figure out how to best get access to `store.getChangedIds` from the the API test. Happy to add tests if you have a suggestion about accessing the store.


