### PR TITLE
Small fixes

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,6 @@ const minified = MINIFY === 'true';
 const outputFile = minified ? 'dist/mapbox-gl-draw.js' : 'dist/mapbox-gl-draw-unminified.js';
 
 import commonjs from '@rollup/plugin-commonjs';
-import replace from '@rollup/plugin-replace';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
@@ -18,10 +17,6 @@ export default {
   },
   treeshake: true,
   plugins: [
-    replace({
-      'process.env.NODE_ENV': "'browser'",
-      preventAssignment: true
-    }),
     minified ? terser({
       ecma: 2020,
       module: true,

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -46,6 +46,11 @@ export default [
         ['==', ['get', 'active'], 'true'], orange,
         blue,
       ],
+      'line-dasharray': [
+        'case',
+        ['==', ['get', 'active'], 'true'], [0.2, 2],
+        [2, 0],
+      ],
       'line-width': 2,
     },
   },

--- a/src/setup.js
+++ b/src/setup.js
@@ -37,22 +37,6 @@ export default function(ctx) {
       ctx.events.addEventListeners();
     },
     onAdd(map) {
-      if (process.env.NODE_ENV !== 'test') {
-        // Monkey patch to resolve breaking change to `fire` introduced by
-        // mapbox-gl-js. See mapbox/mapbox-gl-draw/issues/766.
-        const _fire = map.fire;
-        map.fire = function(type, event) {
-          // eslint-disable-next-line
-          let args = arguments;
-
-          if (_fire.length === 1 && arguments.length !== 1) {
-            args = [Object.assign({}, { type }, event)];
-          }
-
-          return _fire.apply(map, args);
-        };
-      }
-
       ctx.map = map;
       ctx.events = events(ctx);
       ctx.ui = ui(ctx);

--- a/test/fixtures/style_with_sources.json
+++ b/test/fixtures/style_with_sources.json
@@ -62,6 +62,25 @@
         "#fbb03b",
         "#3bb2d0"
       ],
+      "line-dasharray": [
+        "case",
+        [
+          "==",
+          [
+            "get",
+            "active"
+          ],
+          "true"
+        ],
+        [
+          0.2,
+          2
+        ],
+        [
+          2,
+          0
+        ]
+      ],
       "line-width": 2
     },
     "source": "mapbox-gl-draw-cold"
@@ -303,6 +322,25 @@
         ],
         "#fbb03b",
         "#3bb2d0"
+      ],
+      "line-dasharray": [
+        "case",
+        [
+          "==",
+          [
+            "get",
+            "active"
+          ],
+          "true"
+        ],
+        [
+          0.2,
+          2
+        ],
+        [
+          2,
+          0
+        ]
       ],
       "line-width": 2
     },

--- a/test/utils/create_map.js
+++ b/test/utils/create_map.js
@@ -1,4 +1,4 @@
-import bboxClip from '@turf/bbox-clip';
+import {bboxClip} from '@turf/bbox-clip';
 
 import Evented from '../../bench/lib/evented.js';
 import { interactions } from '../../src/constants.js';


### PR DESCRIPTION
* Keep dashed line for the active state in theme. Fix after https://github.com/mapbox/mapbox-gl-draw/pull/1078
* Drop `map.fire` monkey patch. We no longer need this patch since we support both `map.fire` interfaces in GL JS https://github.com/mapbox/mapbox-gl-js/pull/6604