### PR TITLE
chore: Update package.json to Node.js version 18.0.0 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@mapbox/mapbox-gl-draw",
   "version": "1.4.3",
+  "engines": {
+    "node": "^18.0.0 || >=20.0.0"
+  },
   "description": "A drawing component for Mapbox GL JS",
   "author": "mapbox",
   "license": "ISC",


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-draw/pull/1242 switched project to Vite and ESM. This means that this project currently supports node version `^18.0.0 || >=20.0.0` https://vitejs.dev/guide/#scaffolding-your-first-vite-project

By adding `engines.node` to `package.json` we gain some extra features:

- Can automatically create a warning, when someone uses a wrong version
- Automatically use defined Node version, when running project via pnpm
- It will probably also be picked up by CI/CD