### PR TITLE
Emit events on API call with `suppressAPIEvents: false`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -36,6 +36,7 @@ All of the following options are optional.
 - `modes`, Object: over ride the default modes with your own. `MapboxDraw.modes` can be used to see the default values. More information on custom modes [can be found here](https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/MODES.md).
 - `defaultMode`, String (default: `'simple_select'`): the mode (from `modes`) that user will first land in.
 - `userProperties`, boolean (default: `false`): properties of a feature will also be available for styling and prefixed with `user_`, e.g., `['==', 'user_custom_label', 'Example']`
+- `silent`, boolean (default: `true`): Whether or not to emit events when calling Draw API methods. If `false`, events will be emitted.
 
 ## Modes
 
@@ -449,7 +450,7 @@ This event will *not* fire when a feature is created or deleted. To track those 
 The event data is an object with the following shape:
 
 ```js
-{  
+{
   features: Array<Feature>, // Array of features that were updated
   action: string // Name of the action that triggered the update
 }
@@ -493,7 +494,7 @@ This event is fired just after the current mode stops and just before the next m
 The event data is an object with the following shape:
 
 ```js
-{  
+{
   mode: string // The next mode, i.e. the mode that Draw is changing to
 }
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -36,7 +36,7 @@ All of the following options are optional.
 - `modes`, Object: over ride the default modes with your own. `MapboxDraw.modes` can be used to see the default values. More information on custom modes [can be found here](https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/MODES.md).
 - `defaultMode`, String (default: `'simple_select'`): the mode (from `modes`) that user will first land in.
 - `userProperties`, boolean (default: `false`): properties of a feature will also be available for styling and prefixed with `user_`, e.g., `['==', 'user_custom_label', 'Example']`
-- `silent`, boolean (default: `true`): Whether or not to emit events when calling Draw API methods. If `false`, events will be emitted.
+- `suppressAPIEvents`, boolean (default: `true`): Whether or not to emit events when calling Draw API methods. If `false`, events will be emitted.
 
 ## Modes
 

--- a/src/api.js
+++ b/src/api.js
@@ -98,7 +98,7 @@ export default function(ctx, api) {
         const originalProperties = internalFeature.properties;
         internalFeature.properties = feature.properties;
         if (!isEqual(originalProperties, feature.properties)) {
-          ctx.store.featureChanged(internalFeature.id);
+          ctx.store.featureChanged(internalFeature.id, { silent });
         }
         if (!isEqual(internalFeature.getCoordinates(), feature.geometry.coordinates)) {
           internalFeature.incomingCoords(feature.geometry.coordinates);

--- a/src/api.js
+++ b/src/api.js
@@ -24,7 +24,7 @@ export default function(ctx, api) {
   api.modes = Constants.modes;
 
   // API doesn't emit events by default
-  const silent = ctx.options.silent !== undefined ? !!ctx.options.silent : true;
+  const silent = ctx.options.suppressAPIEvents !== undefined ? !!ctx.options.suppressAPIEvents : true;
 
   api.getFeatureIdsAt = function(point) {
     const features = featuresAt.click({ point }, null, ctx);

--- a/src/api.js
+++ b/src/api.js
@@ -192,7 +192,7 @@ export default function(ctx, api) {
   };
 
   api.setFeatureProperty = function(featureId, property, value) {
-    ctx.store.setFeatureProperty(featureId, property, value);
+    ctx.store.setFeatureProperty(featureId, property, value, { silent });
     return api;
   };
 

--- a/src/api.js
+++ b/src/api.js
@@ -21,26 +21,28 @@ const featureTypes = {
 };
 
 export default function(ctx, api) {
-
   api.modes = Constants.modes;
+
+  // API doesn't emit events by default
+  const silent = ctx.options.silent !== undefined ? !!ctx.options.silent : true;
 
   api.getFeatureIdsAt = function(point) {
     const features = featuresAt.click({ point }, null, ctx);
     return features.map(feature => feature.properties.id);
   };
 
-  api.getSelectedIds = function () {
+  api.getSelectedIds = function() {
     return ctx.store.getSelectedIds();
   };
 
-  api.getSelected = function () {
+  api.getSelected = function() {
     return {
       type: Constants.geojsonTypes.FEATURE_COLLECTION,
       features: ctx.store.getSelectedIds().map(id => ctx.store.get(id)).map(feature => feature.toGeoJSON())
     };
   };
 
-  api.getSelectedPoints = function () {
+  api.getSelectedPoints = function() {
     return {
       type: Constants.geojsonTypes.FEATURE_COLLECTION,
       features: ctx.store.getSelectedCoordinates().map(coordinate => ({
@@ -72,7 +74,7 @@ export default function(ctx, api) {
     return newIds;
   };
 
-  api.add = function (geojson) {
+  api.add = function(geojson) {
     const featureCollection = JSON.parse(JSON.stringify(normalize(geojson)));
 
     const ids = featureCollection.features.map((feature) => {
@@ -89,7 +91,7 @@ export default function(ctx, api) {
           throw new Error(`Invalid geometry type: ${feature.geometry.type}.`);
         }
         const internalFeature = new Model(ctx, feature);
-        ctx.store.add(internalFeature);
+        ctx.store.add(internalFeature, { silent });
       } else {
         // If a feature of that id has already been created, and we are swapping it out ...
         const internalFeature = ctx.store.get(feature.id);
@@ -110,7 +112,7 @@ export default function(ctx, api) {
   };
 
 
-  api.get = function (id) {
+  api.get = function(id) {
     const feature = ctx.store.get(id);
     if (feature) {
       return feature.toGeoJSON();
@@ -125,11 +127,11 @@ export default function(ctx, api) {
   };
 
   api.delete = function(featureIds) {
-    ctx.store.delete(featureIds, { silent: true });
+    ctx.store.delete(featureIds, { silent });
     // If we were in direct select mode and our selected feature no longer exists
     // (because it was deleted), we need to get out of that mode.
     if (api.getMode() === Constants.modes.DIRECT_SELECT && !ctx.store.getSelectedIds().length) {
-      ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent: true });
+      ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent });
     } else {
       ctx.store.render();
     }
@@ -138,11 +140,11 @@ export default function(ctx, api) {
   };
 
   api.deleteAll = function() {
-    ctx.store.delete(ctx.store.getAllIds(), { silent: true });
+    ctx.store.delete(ctx.store.getAllIds(), { silent });
     // If we were in direct select mode, now our selected feature no longer exists,
     // so escape that mode.
     if (api.getMode() === Constants.modes.DIRECT_SELECT) {
-      ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent: true });
+      ctx.events.changeMode(Constants.modes.SIMPLE_SELECT, undefined, { silent });
     } else {
       ctx.store.render();
     }
@@ -156,7 +158,7 @@ export default function(ctx, api) {
       if (stringSetsAreEqual((modeOptions.featureIds || []), ctx.store.getSelectedIds())) return api;
       // And if we are changing the selection within simple_select mode, just change the selection,
       // instead of stopping and re-starting the mode
-      ctx.store.setSelected(modeOptions.featureIds, { silent: true });
+      ctx.store.setSelected(modeOptions.featureIds, { silent });
       ctx.store.render();
       return api;
     }
@@ -166,7 +168,7 @@ export default function(ctx, api) {
       return api;
     }
 
-    ctx.events.changeMode(mode, modeOptions, { silent: true });
+    ctx.events.changeMode(mode, modeOptions, { silent });
     return api;
   };
 
@@ -175,17 +177,17 @@ export default function(ctx, api) {
   };
 
   api.trash = function() {
-    ctx.events.trash({ silent: true });
+    ctx.events.trash({ silent });
     return api;
   };
 
   api.combineFeatures = function() {
-    ctx.events.combineFeatures({ silent: true });
+    ctx.events.combineFeatures({ silent });
     return api;
   };
 
   api.uncombineFeatures = function() {
-    ctx.events.uncombineFeatures({ silent: true });
+    ctx.events.uncombineFeatures({ silent });
     return api;
   };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -68,6 +68,7 @@ export const events = {
 
 export const updateActions = {
   MOVE: 'move',
+  CHANGE_PROPERTIES: 'change_properties',
   CHANGE_COORDINATES: 'change_coordinates'
 };
 

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -9,17 +9,17 @@ const Feature = function(ctx, geojson) {
   this.type = geojson.geometry.type;
 };
 
-Feature.prototype.changed = function() {
-  this.ctx.store.featureChanged(this.id);
+Feature.prototype.changed = function(options = {}) {
+  this.ctx.store.featureChanged(this.id, options);
 };
 
 Feature.prototype.incomingCoords = function(coords) {
   this.setCoordinates(coords);
 };
 
-Feature.prototype.setCoordinates = function(coords) {
+Feature.prototype.setCoordinates = function(coords, options = {}) {
   this.coordinates = coords;
-  this.changed();
+  this.changed(options);
 };
 
 Feature.prototype.getCoordinates = function() {

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -9,17 +9,17 @@ const Feature = function(ctx, geojson) {
   this.type = geojson.geometry.type;
 };
 
-Feature.prototype.changed = function(options = {}) {
-  this.ctx.store.featureChanged(this.id, options);
+Feature.prototype.changed = function() {
+  this.ctx.store.featureChanged(this.id);
 };
 
 Feature.prototype.incomingCoords = function(coords) {
   this.setCoordinates(coords);
 };
 
-Feature.prototype.setCoordinates = function(coords, options = {}) {
+Feature.prototype.setCoordinates = function(coords) {
   this.coordinates = coords;
-  this.changed(options);
+  this.changed();
 };
 
 Feature.prototype.getCoordinates = function() {

--- a/src/modes/mode_interface_accessors.js
+++ b/src/modes/mode_interface_accessors.js
@@ -107,8 +107,8 @@ ModeInterface.prototype.deleteFeature = function(id, opts = {}) {
  * @name this.addFeature
  * @param {DrawFeature} feature - the feature to add
  */
-ModeInterface.prototype.addFeature = function(feature) {
-  return this._ctx.store.add(feature);
+ModeInterface.prototype.addFeature = function(feature, opts = {}) {
+  return this._ctx.store.add(feature, opts);
 };
 
 /**

--- a/src/options.js
+++ b/src/options.js
@@ -15,7 +15,7 @@ const defaultOptions = {
   modes,
   controls: {},
   userProperties: false,
-  silent: true
+  suppressAPIEvents: true
 };
 
 const showControls = {

--- a/src/options.js
+++ b/src/options.js
@@ -14,7 +14,8 @@ const defaultOptions = {
   styles,
   modes,
   controls: {},
-  userProperties: false
+  userProperties: false,
+  silent: true
 };
 
 const showControls = {

--- a/src/store.js
+++ b/src/store.js
@@ -87,7 +87,7 @@ Store.prototype.setDirty = function() {
 Store.prototype.featureCreated = function(featureId, options = {}) {
   this._changedFeatureIds.add(featureId);
 
-  const silent = options.silent != null ? options.silent : this.ctx.options.silent;
+  const silent = options.silent != null ? options.silent : this.ctx.options.suppressAPIEvents;
   if (silent !== true) {
     const feature = this.get(featureId);
     this.ctx.events.fire(Constants.events.CREATE, {
@@ -106,7 +106,7 @@ Store.prototype.featureCreated = function(featureId, options = {}) {
 Store.prototype.featureChanged = function(featureId, options = {}) {
   this._changedFeatureIds.add(featureId);
 
-  const silent = options.silent != null ? options.silent : this.ctx.options.silent;
+  const silent = options.silent != null ? options.silent : this.ctx.options.suppressAPIEvents;
   if (silent !== true) {
     this.ctx.events.fire(Constants.events.UPDATE, {
       action: options.action ? options.action : Constants.updateActions.CHANGE_COORDINATES,

--- a/src/store.js
+++ b/src/store.js
@@ -128,7 +128,7 @@ Store.prototype.add = function(feature, options = {}) {
   this._featureIds.add(feature.id);
 
   if (options.silent != null && options.silent === false) {
-    this.ctx.map.fire(Constants.events.CREATE, {
+    this.ctx.events.fire(Constants.events.CREATE, {
       features: [this._features[feature.id].toGeoJSON()]
     });
   }
@@ -322,9 +322,16 @@ Store.prototype.isSelected = function(featureId) {
  * @param {string} property property
  * @param {string} property value
 */
-Store.prototype.setFeatureProperty = function(featureId, property, value) {
+Store.prototype.setFeatureProperty = function(featureId, property, value, options) {
   this.get(featureId).setProperty(property, value);
   this.featureChanged(featureId);
+
+  if (options.silent != null && options.silent === false) {
+    this.ctx.events.fire(Constants.events.UPDATE, {
+      action: Constants.updateActions.CHANGE_PROPERTIES,
+      features: [this.get(featureId).toGeoJSON()]
+    });
+  }
 };
 
 function refreshSelectedCoordinates(store, options) {

--- a/src/store.js
+++ b/src/store.js
@@ -117,13 +117,22 @@ Store.prototype.getAllIds = function() {
 /**
  * Adds a feature to the store.
  * @param {Object} feature
+ * @param {Object} [options]
+ * @param {Object} [options.silent] - If `true`, this invocation will not fire an event.
  *
  * @return {Store} this
  */
-Store.prototype.add = function(feature) {
+Store.prototype.add = function(feature, options = {}) {
   this.featureChanged(feature.id);
   this._features[feature.id] = feature;
   this._featureIds.add(feature.id);
+
+  if (options.silent != null && options.silent === false) {
+    this.ctx.map.fire(Constants.events.CREATE, {
+      features: [this._features[feature.id].toGeoJSON()]
+    });
+  }
+
   return this;
 };
 

--- a/src/store.js
+++ b/src/store.js
@@ -322,7 +322,7 @@ Store.prototype.isSelected = function(featureId) {
  * @param {string} property property
  * @param {string} property value
 */
-Store.prototype.setFeatureProperty = function(featureId, property, value, options) {
+Store.prototype.setFeatureProperty = function(featureId, property, value, options = {}) {
   this.get(featureId).setProperty(property, value);
   this.featureChanged(featureId);
 
@@ -334,7 +334,7 @@ Store.prototype.setFeatureProperty = function(featureId, property, value, option
   }
 };
 
-function refreshSelectedCoordinates(store, options) {
+function refreshSelectedCoordinates(store, options = {}) {
   const newSelectedCoordinates = store._selectedCoordinates.filter(point => store._selectedFeatureIds.has(point.feature_id));
   if (store._selectedCoordinates.length !== newSelectedCoordinates.length && !options.silent) {
     store._emitSelectionChange = true;

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -139,11 +139,11 @@ test('Draw.set', () => {
     'Draw.add called with new collection');
   assert.equal(deleteSpy.callCount, 1,
     'Draw.delete called');
-  assert.deepEqual(deleteSpy.getCall(0).args, [[
+  assert.deepEqual(deleteSpy.getCall(0).args[0], [
     pointId,
     lineId,
     polygonId
-  ]], 'Draw.delete called with old features');
+  ], 'Draw.delete called with old features');
 
   // Then set to another that contains a feature
   // with an already-used id

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -50,9 +50,7 @@ test('Feature#changed', () => {
   ctx.store.featureChanged.resetHistory();
   feature.changed();
   assert.equal(ctx.store.featureChanged.callCount, 1, 'called function on store');
-  assert.deepEqual(ctx.store.featureChanged.getCall(0).args, [featureGeoJson.id], 'with correct args');
-
-
+  assert.deepEqual(ctx.store.featureChanged.getCall(0).args[0], featureGeoJson.id, 'with correct args');
 });
 
 test('Feature#incomingCoords', () => {

--- a/test/interaction_events.test.js
+++ b/test/interaction_events.test.js
@@ -989,8 +989,8 @@ test('ensure API fire right events', async (t) => {
   const map = createMap({container});
   const fireSpy = spy(map, 'fire');
 
-  // Explicitly set silent to false to ensure events are fired
-  const Draw = new MapboxDraw({ silent: false });
+  // Explicitly set `suppressAPIEvents` to false to ensure events are fired
+  const Draw = new MapboxDraw({ suppressAPIEvents: false });
 
   map.addControl(Draw);
   await map.on('load');

--- a/test/interaction_events.test.js
+++ b/test/interaction_events.test.js
@@ -983,7 +983,7 @@ test('ensure user interactions fire right events', async (t) => {
   });
 });
 
-test('ensure API fire right events', { only: true }, async (t) => {
+test('ensure API fire right events', async (t) => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const map = createMap({container});

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -32,7 +32,8 @@ test('Options test', async (t) => {
         trash: true,
         combine_features: true,
         uncombine_features: true
-      }
+      },
+      silent: true
     };
     assert.deepEqual(defaultOptions, Draw.options);
     assert.deepEqual(styleWithSourcesFixture, Draw.options.styles);
@@ -58,7 +59,8 @@ test('Options test', async (t) => {
         trash: true,
         combine_features: true,
         uncombine_features: true
-      }
+      },
+      silent: true
     };
 
     assert.deepEqual(defaultOptions, Draw.options);
@@ -84,7 +86,8 @@ test('Options test', async (t) => {
         trash: false,
         combine_features: false,
         uncombine_features: false
-      }
+      },
+      silent: true
     };
     assert.deepEqual(defaultOptions, Draw.options);
   });
@@ -109,7 +112,8 @@ test('Options test', async (t) => {
         trash: false,
         combine_features: false,
         uncombine_features: false
-      }
+      },
+      silent: true
     };
 
     assert.deepEqual(defaultOptions, Draw.options);
@@ -135,7 +139,8 @@ test('Options test', async (t) => {
         trash: true,
         combine_features: true,
         uncombine_features: true
-      }
+      },
+      silent: true
     };
 
     assert.deepEqual(defaultOptions, Draw.options);
@@ -161,7 +166,8 @@ test('Options test', async (t) => {
         trash: true,
         combine_features: true,
         uncombine_features: true
-      }
+      },
+      silent: true
     };
     assert.deepEqual(defaultOptions, Draw.options);
     assert.deepEqual(styleWithSourcesFixture, Draw.options.styles);

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -33,7 +33,7 @@ test('Options test', async (t) => {
         combine_features: true,
         uncombine_features: true
       },
-      silent: true
+      suppressAPIEvents: true
     };
     assert.deepEqual(defaultOptions, Draw.options);
     assert.deepEqual(styleWithSourcesFixture, Draw.options.styles);
@@ -60,7 +60,7 @@ test('Options test', async (t) => {
         combine_features: true,
         uncombine_features: true
       },
-      silent: true
+      suppressAPIEvents: true
     };
 
     assert.deepEqual(defaultOptions, Draw.options);
@@ -87,7 +87,7 @@ test('Options test', async (t) => {
         combine_features: false,
         uncombine_features: false
       },
-      silent: true
+      suppressAPIEvents: true
     };
     assert.deepEqual(defaultOptions, Draw.options);
   });
@@ -113,7 +113,7 @@ test('Options test', async (t) => {
         combine_features: false,
         uncombine_features: false
       },
-      silent: true
+      suppressAPIEvents: true
     };
 
     assert.deepEqual(defaultOptions, Draw.options);
@@ -140,7 +140,7 @@ test('Options test', async (t) => {
         combine_features: true,
         uncombine_features: true
       },
-      silent: true
+      suppressAPIEvents: true
     };
 
     assert.deepEqual(defaultOptions, Draw.options);
@@ -167,7 +167,7 @@ test('Options test', async (t) => {
         combine_features: true,
         uncombine_features: true
       },
-      silent: true
+      suppressAPIEvents: true
     };
     assert.deepEqual(defaultOptions, Draw.options);
     assert.deepEqual(styleWithSourcesFixture, Draw.options.styles);

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -46,6 +46,7 @@ test('Store constructor and public API', () => {
   // prototype members
   assert.equal(typeof Store.prototype.setDirty, 'function', 'exposes store.setDirty');
   assert.equal(typeof Store.prototype.createRenderBatch, 'function', 'exposes store.createRenderBatch');
+  assert.equal(typeof Store.prototype.featureCreated, 'function', 'exposes store.featureCreated');
   assert.equal(typeof Store.prototype.featureChanged, 'function', 'exposes store.featureChanged');
   assert.equal(typeof Store.prototype.getChangedIds, 'function', 'exposes store.getChangedIds');
   assert.equal(typeof Store.prototype.clearChangedIds, 'function', 'exposes store.clearChangedIds');
@@ -69,7 +70,7 @@ test('Store constructor and public API', () => {
   assert.equal(typeof Store.prototype.restoreMapConfig, 'function', 'exposes store.restoreMapConfig');
   assert.equal(typeof Store.prototype.getInitialConfigValue, 'function', 'exposes store.getInitialConfigValue');
 
-  assert.equal(getPublicMemberKeys(Store.prototype).length, 24, 'no untested prototype members');
+  assert.equal(getPublicMemberKeys(Store.prototype).length, 25, 'no untested prototype members');
 });
 
 test('Store#setDirty', () => {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -9,6 +9,9 @@ import createMap from './utils/create_map.js';
 
 function createStore() {
   const ctx = {
+    options: {
+      silent: true
+    },
     map: createMap(),
     events: {
       fire: spy()

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -10,7 +10,7 @@ import createMap from './utils/create_map.js';
 function createStore() {
   const ctx = {
     options: {
-      silent: true
+      suppressAPIEvents: true
     },
     map: createMap(),
     events: {


### PR DESCRIPTION
- Add `suppressAPIEvents` (`true` by default) option to `Draw` to emit events after API methods (like `add`, `delete`, etc) calls