### PR TITLE
Use native `crypto.randomUUID()` instead of `hat` module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "@mapbox/geojson-area": "^0.2.2",
         "@mapbox/geojson-normalize": "^0.0.1",
         "@mapbox/point-geometry": "^0.1.0",
-        "fast-deep-equal": "^3.1.3",
-        "hat": "0.0.3"
+        "fast-deep-equal": "^3.1.3"
       },
       "devDependencies": {
         "@mapbox/cloudfriend": "^8.1.0",
@@ -5018,10 +5017,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/hat": {
-      "version": "0.0.3",
-      "license": "MIT/X11"
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "@mapbox/geojson-area": "^0.2.2",
     "@mapbox/geojson-normalize": "^0.0.1",
     "@mapbox/point-geometry": "^0.1.0",
-    "fast-deep-equal": "^3.1.3",
-    "hat": "0.0.3"
+    "fast-deep-equal": "^3.1.3"
   },
   "files": [
     "src",

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,5 @@
 import isEqual from 'fast-deep-equal';
 import normalize from '@mapbox/geojson-normalize';
-import hat from 'hat';
 import featuresAt from './lib/features_at.js';
 import stringSetsAreEqual from './lib/string_sets_are_equal.js';
 import * as Constants from './constants.js';
@@ -76,7 +75,7 @@ export default function(ctx, api) {
     const featureCollection = JSON.parse(JSON.stringify(normalize(geojson)));
 
     const ids = featureCollection.features.map((feature) => {
-      feature.id = feature.id || hat();
+      feature.id = feature.id || crypto.randomUUID();
 
       if (feature.geometry === null) {
         throw new Error('Invalid geometry: null');

--- a/src/feature_types/feature.js
+++ b/src/feature_types/feature.js
@@ -1,11 +1,10 @@
-import hat from 'hat';
 import * as Constants from '../constants.js';
 
 const Feature = function(ctx, geojson) {
   this.ctx = ctx;
   this.properties = geojson.properties || {};
   this.coordinates = geojson.geometry.coordinates;
-  this.id = geojson.id || hat();
+  this.id = geojson.id || crypto.randomUUID();
   this.type = geojson.geometry.type;
 };
 

--- a/src/feature_types/multi_feature.js
+++ b/src/feature_types/multi_feature.js
@@ -1,4 +1,3 @@
-import hat from 'hat';
 import Feature from './feature.js';
 import * as Constants from '../constants.js';
 
@@ -33,7 +32,7 @@ MultiFeature.prototype = Object.create(Feature.prototype);
 MultiFeature.prototype._coordinatesToFeatures = function(coordinates) {
   const Model = this.model.bind(this);
   return coordinates.map(coords => new Model(this.ctx, {
-    id: hat(),
+    id: crypto.randomUUID(),
     type: Constants.geojsonTypes.FEATURE,
     properties: {},
     geometry: {

--- a/test/utils/create_feature.js
+++ b/test/utils/create_feature.js
@@ -1,11 +1,8 @@
-import hat from 'hat';
 import getGeoJSON from './get_geojson.js';
-
-const hatRack = hat.rack();
 
 export default function createFeature(featureType) {
   const feature = Object.assign({
-    id: hatRack(),
+    id: crypto.randomUUID(),
     properties: {}
   }, getGeoJSON(featureType));
   feature.toGeoJSON = () => feature;


### PR DESCRIPTION
Reducing number of dependencies by replacing `hat` module with native `crypto.randomUUID()` which is well supported:

https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility
https://caniuse.com/mdn-api_crypto_randomuuid

This would push `mapbox-gl-draw` dev env to node 20 (or deno/bun). Node 18 is reaching end of maintenance next year, so idk if that's an issue for you.
