### PR TITLE
fix: update exports to work with current release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,12 @@
     "drawing"
   ],
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./dist/mapbox-gl-draw-unminified.js": "./dist/mapbox-gl-draw-unminified.js",
+    "./dist/mapbox-gl-draw.js": "./dist/mapbox-gl-draw.js",
+    "./dist/mapbox-gl-draw.css": "./dist/mapbox-gl-draw.css"
+  },
   "main": "dist/mapbox-gl-draw.js",
   "browser": "dist/mapbox-gl-draw.js",
   "style": "dist/mapbox-gl-draw.css",


### PR DESCRIPTION
At the moment, the release version of this package doesn't work anymore when imported into another project.
This fix allows ESM imports to work again.