### PR TITLE
Fix: Ensure coord_path is a string in DirectSelect.onVertex

### DIFF
--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -47,6 +47,7 @@ DirectSelect.stopDragging = function(state) {
 DirectSelect.onVertex = function (state, e) {
   this.startDragging(state, e);
   const about = e.featureTarget.properties;
+  if (typeof about.coord_path !== 'string') about.coord_path = String(about.coord_path);
   const selectedIndex = state.selectedCoordPaths.indexOf(about.coord_path);
   if (!isShiftDown(e) && selectedIndex === -1) {
     state.selectedCoordPaths = [about.coord_path];


### PR DESCRIPTION
### Problem
`DirectSelect.onVertex` fails when dragging `MultiPoint` geometries due to the `coord_path` property not being consistently a string. This causes issues, especially when dragging vertices in `MultiPoint` geometries.

### Solution
- Added a type check and conversion for `coord_path` to ensure it is always treated as a string:
  ```javascript
  if (typeof about.coord_path !== 'string') about.coord_path = String(about.coord_path);
