### PR TITLE
fix: GL draw lines default style is broken for line-dashArray

### DIFF
--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -48,8 +48,9 @@ export default [
       ],
       'line-dasharray': [
         'case',
-        ['==', ['get', 'active'], 'true'], [0.2, 2],
-        [2, 0],
+        ['==', ['get', 'active'], 'true'],
+        ['literal', [0.2, 2]],
+        ['literal', [2, 0]],
       ],
       'line-width': 2,
     },


### PR DESCRIPTION
## Summary
Resolving an issue in the default style theme which is causing the drawn lines to disappear by default:
![image](https://github.com/user-attachments/assets/d63482a0-bafb-4b12-aab6-1fff9e65fecb)


## Solution
Fix the line-dashArray to use literals for the array