### PR TITLE
Fix: In direct_select mode it's better to prefer selecting vertices than midpoints

### DIFF
--- a/src/lib/sort_features.js
+++ b/src/lib/sort_features.js
@@ -8,11 +8,22 @@ const FEATURE_SORT_RANKS = {
   Polygon: 2
 };
 
+const POINT_META_RANKS = {
+  vertex: 0,
+  midpoint: 1,
+  feature: 2
+};
+
 function comparator(a, b) {
   const score = FEATURE_SORT_RANKS[a.geometry.type] - FEATURE_SORT_RANKS[b.geometry.type];
 
   if (score === 0 && a.geometry.type === Constants.geojsonTypes.POLYGON) {
     return a.area - b.area;
+  }
+
+  // Always consider vertices before midpoints!
+  if (score === 0 && a.geometry.type === Constants.geojsonTypes.POINT) {
+    return POINT_META_RANKS[a.properties.meta] - POINT_META_RANKS[b.properties.meta];
   }
 
   return score;


### PR DESCRIPTION
When a polygon or a polyline contains two vertices very close to each other, it can be very tricky to click on one of them and not on the midpoint between them.

The result is very frustrating, because this would create yet another vertex (and if user decides to click multiple times, it would produce even more vertices). This issue is even worse on touch devices (because `touchBuffer` is much bigger than `clickBuffer`).

This commit fixes the issue by tweaking the sort order of points: if there are more than one vertex near the cursor, we should always try to select an existing vertex instead of creating a new one.