### PR TITLE
Fix midpoints locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mapbox/geojson-area": "^0.2.2",
         "@mapbox/geojson-normalize": "^0.0.1",
         "@mapbox/point-geometry": "^1.1.0",
+        "@turf/projection": "^7.2.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^5.0.9"
       },
@@ -2691,11 +2692,24 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/clone": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.2.0.tgz",
+      "integrity": "sha512-JlGUT+/5qoU5jqZmf6NMFIoLDY3O7jKd53Up+zbpJ2vzUp6QdwdNzwrsCeONhynWM13F0MVtPXH4AtdkrgFk4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/helpers": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
       "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
-      "dev": true,
       "dependencies": {
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
@@ -2722,10 +2736,25 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
       "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
-      "dev": true,
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.2.0.tgz",
+      "integrity": "sha512-/qke5vJScv8Mu7a+fU3RSChBRijE6EVuFHU3RYihMuYm04Vw8dBMIs0enEpoq0ke/IjSbleIrGQNZIMRX9EwZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "^7.2.0",
+        "@turf/helpers": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -2754,7 +2783,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/geojson-vt": {
@@ -7653,8 +7681,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@mapbox/geojson-area": "^0.2.2",
     "@mapbox/geojson-normalize": "^0.0.1",
     "@mapbox/point-geometry": "^1.1.0",
+    "@turf/projection": "^7.2.0",
     "fast-deep-equal": "^3.1.3",
     "nanoid": "^5.0.9"
   },

--- a/src/lib/create_midpoint.js
+++ b/src/lib/create_midpoint.js
@@ -1,5 +1,10 @@
 import * as Constants from '../constants.js';
+import { toMercator, toWgs84 } from '@turf/projection';
 
+/**
+ * Calculate the midpoint in Web Mercator, then convert back to Mercator
+ * to ensure the midpoint appears on the projected line.
+ */
 export default function(parent, startVertex, endVertex) {
   const startCoord = startVertex.geometry.coordinates;
   const endCoord = endVertex.geometry.coordinates;
@@ -13,23 +18,34 @@ export default function(parent, startVertex, endVertex) {
     return null;
   }
 
-  const mid = {
-    lng: (startCoord[0] + endCoord[0]) / 2,
-    lat: (startCoord[1] + endCoord[1]) / 2
-  };
+  const start = toMercator(startCoord);
+  const end = toMercator(endCoord);
+
+  const round = num => Number(num.toFixed(8));
+  const getMidpoint = (a, b) => (a + b) / 2;
+
+  const midpointRaw = toWgs84([
+    getMidpoint(start[0], end[0]),
+    getMidpoint(start[1], end[1])
+  ]);
+
+  const midpoint = [
+    round(midpointRaw[0]),
+    round(midpointRaw[1])
+  ];
 
   return {
     type: Constants.geojsonTypes.FEATURE,
     properties: {
       meta: Constants.meta.MIDPOINT,
       parent,
-      lng: mid.lng,
-      lat: mid.lat,
+      lng: midpoint[0],
+      lat: midpoint[1],
       coord_path: endVertex.properties.coord_path
     },
     geometry: {
       type: Constants.geojsonTypes.POINT,
-      coordinates: [mid.lng, mid.lat]
+      coordinates: midpoint
     }
   };
 }

--- a/test/create_supplementary_points.test.js
+++ b/test/create_supplementary_points.test.js
@@ -188,12 +188,12 @@ test('createSupplementaryPoints with line, midpoints, selected coordinate', () =
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [2, 2],
+      coordinates: [2, 2.00121958],
       type: 'Point'
     },
     properties: {
       coord_path: '1',
-      lat: 2,
+      lat: 2.00121958,
       lng: 2,
       meta: 'midpoint',
       parent: 'foo'
@@ -213,12 +213,12 @@ test('createSupplementaryPoints with line, midpoints, selected coordinate', () =
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [6, 6],
+      coordinates: [6, 6.00367071],
       type: 'Point'
     },
     properties: {
       coord_path: '2',
-      lat: 6,
+      lat: 6.00367071,
       lng: 6,
       meta: 'midpoint',
       parent: 'foo'
@@ -275,12 +275,12 @@ test('createSupplementaryPoints with polygon, midpoints, selection', () => {
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [1.5, 1.5],
+      coordinates: [1.5, 1.50005713],
       type: 'Point'
     },
     properties: {
       coord_path: '0.1',
-      lat: 1.5,
+      lat: 1.50005713,
       lng: 1.5,
       meta: 'midpoint',
       parent: 'foo'
@@ -300,12 +300,12 @@ test('createSupplementaryPoints with polygon, midpoints, selection', () => {
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [2.5, 2.5],
+      coordinates: [2.5, 2.50009526],
       type: 'Point'
     },
     properties: {
       coord_path: '0.2',
-      lat: 2.5,
+      lat: 2.50009526,
       lng: 2.5,
       meta: 'midpoint',
       parent: 'foo'
@@ -325,12 +325,12 @@ test('createSupplementaryPoints with polygon, midpoints, selection', () => {
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [3.5, 3.5],
+      coordinates: [3.5, 3.50013344],
       type: 'Point'
     },
     properties: {
       coord_path: '0.3',
-      lat: 3.5,
+      lat: 3.50013344,
       lng: 3.5,
       meta: 'midpoint',
       parent: 'foo'
@@ -350,12 +350,12 @@ test('createSupplementaryPoints with polygon, midpoints, selection', () => {
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [2.5, 2.5],
+      coordinates: [2.5, 2.50085753],
       type: 'Point'
     },
     properties: {
       coord_path: '0.4',
-      lat: 2.5,
+      lat: 2.50085753,
       lng: 2.5,
       meta: 'midpoint',
       parent: 'foo'
@@ -402,12 +402,12 @@ test('createSupplementaryPoints with MultiLineString, midpoints, selected coordi
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [2, 2],
+      coordinates: [2, 2.00121958],
       type: 'Point'
     },
     properties: {
       coord_path: '0.1',
-      lat: 2,
+      lat: 2.00121958,
       lng: 2,
       meta: 'midpoint',
       parent: 'foo'
@@ -427,12 +427,12 @@ test('createSupplementaryPoints with MultiLineString, midpoints, selected coordi
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [6, 6],
+      coordinates: [6, 6.00367071],
       type: 'Point'
     },
     properties: {
       coord_path: '0.2',
-      lat: 6,
+      lat: 6.00367071,
       lng: 6,
       meta: 'midpoint',
       parent: 'foo'
@@ -464,12 +464,12 @@ test('createSupplementaryPoints with MultiLineString, midpoints, selected coordi
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [22, 22],
+      coordinates: [22, 22.01411104],
       type: 'Point'
     },
     properties: {
       coord_path: '1.1',
-      lat: 22,
+      lat: 22.01411104,
       lng: 22,
       meta: 'midpoint',
       parent: 'foo'
@@ -489,12 +489,12 @@ test('createSupplementaryPoints with MultiLineString, midpoints, selected coordi
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [26, 26],
+      coordinates: [26, 26.01703496],
       type: 'Point'
     },
     properties: {
       coord_path: '1.2',
-      lat: 26,
+      lat: 26.01703496,
       lng: 26,
       meta: 'midpoint',
       parent: 'foo'
@@ -548,12 +548,12 @@ test('createSupplementaryPoints with a line, not all midpoints rendered because 
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [2, 2],
+      coordinates: [2, 2.00121958],
       type: 'Point'
     },
     properties: {
       coord_path: '1',
-      lat: 2,
+      lat: 2.00121958,
       lng: 2,
       meta: 'midpoint',
       parent: 'foo'
@@ -620,12 +620,12 @@ test('createSupplementaryPoints with a line, not all midpoints rendered because 
     type: 'Feature'
   }, {
     geometry: {
-      coordinates: [2, 2],
+      coordinates: [2, 2.00121958],
       type: 'Point'
     },
     properties: {
       coord_path: '1',
-      lat: 2,
+      lat: 2.00121958,
       lng: 2,
       meta: 'midpoint',
       parent: 'foo'

--- a/test/interaction_events.test.js
+++ b/test/interaction_events.test.js
@@ -395,14 +395,14 @@ test('ensure user interactions fire right events', async (t) => {
     properties: {},
     geometry: {
       type: 'LineString',
-      coordinates: [[20, 0], [41, 21], [62, 42], [60, 40]]
+      coordinates: [[20, 0], [41, 22.57323626], [62, 42], [60, 40]]
     }
   };
 
   await t.test('add another vertex', async () => {
     // Now in `direct_select` mode ...
     // Click a midpoint of lineC
-    click(map, makeMouseEvent(41, 21));
+    click(map, makeMouseEvent(41, 23));
     await afterNextRender();
     firedWith('draw.update', {
       action: 'change_coordinates',


### PR DESCRIPTION
Fixes the midpoint location, so they appear on the polygon lines.

Issues was that the midpoint calculation was done in Mercator WGS84, whereas the projection is in Web Mercator.
- Uses [@turf/projection](https://github.com/Turfjs/turf/tree/master/packages/turf-projection) for the conversion
- Fixed tests to accommodate for the new midpoint position

Closes https://github.com/mapbox/mapbox-gl-draw/issues/1073.

Any feedback is welcomed.

---

### _Before :_
<img width="1017" height="793" alt="Screenshot 2025-08-04 at 22 17 09" src="https://github.com/user-attachments/assets/8c516430-da1f-41d2-92cf-9981e7d1df28" />

### _After :_
<img width="1099" height="815" alt="Screenshot 2025-08-04 at 22 14 44" src="https://github.com/user-attachments/assets/39b282d7-e374-42de-9001-87cc5fb0a9dc" />

<img width="695" height="529" alt="Screenshot 2025-08-04 at 22 15 06" src="https://github.com/user-attachments/assets/3fde773c-0bde-4764-adc4-0e218cd3bea7" />
