### PR TITLE
Avoid duplicate layers when a style already defines a source

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -37,13 +37,10 @@ const hideControls = {
 };
 
 function addSources(styles, sourceBucket) {
-  return styles.map((style) => {
-    if (style.source) return style;
-    return Object.assign({}, style, {
-      id: `${style.id}.${sourceBucket}`,
-      source: (sourceBucket === 'hot') ? Constants.sources.HOT : Constants.sources.COLD
-    });
-  });
+  return styles.map((style) => Object.assign({}, style, {
+    id: `${style.id}.${sourceBucket}`,
+    source: (sourceBucket === 'hot') ? Constants.sources.HOT : Constants.sources.COLD
+  }));
 }
 
 export default function(options = {}) {
@@ -62,7 +59,11 @@ export default function(options = {}) {
   withDefaults = Object.assign({}, defaultOptions, withDefaults);
 
   // Layers with a shared source should be adjacent for performance reasons
-  withDefaults.styles = addSources(withDefaults.styles, 'cold').concat(addSources(withDefaults.styles, 'hot'));
+  const sourcedStyles = withDefaults.styles.filter((style) => style.source);
+  const unsourcedStyles = withDefaults.styles.filter((style) => !style.source);
+  withDefaults.styles = sourcedStyles
+    .concat(addSources(unsourcedStyles, 'cold'))
+    .concat(addSources(unsourcedStyles, 'hot'));
 
   return withDefaults;
 }

--- a/src/options.js
+++ b/src/options.js
@@ -37,13 +37,10 @@ const hideControls = {
 };
 
 function addSources(styles, sourceBucket) {
-  return styles.map((style) => {
-    if (style.source) return style;
-    return Object.assign({}, style, {
-      id: `${style.id}.${sourceBucket}`,
-      source: (sourceBucket === 'hot') ? Constants.sources.HOT : Constants.sources.COLD
-    });
-  });
+  return styles.map(style => Object.assign({}, style, {
+    id: `${style.id}.${sourceBucket}`,
+    source: (sourceBucket === 'hot') ? Constants.sources.HOT : Constants.sources.COLD
+  }));
 }
 
 export default function(options = {}) {
@@ -62,7 +59,11 @@ export default function(options = {}) {
   withDefaults = Object.assign({}, defaultOptions, withDefaults);
 
   // Layers with a shared source should be adjacent for performance reasons
-  withDefaults.styles = addSources(withDefaults.styles, 'cold').concat(addSources(withDefaults.styles, 'hot'));
+  const sourcedStyles = withDefaults.styles.filter(style => style.source);
+  const unsourcedStyles = withDefaults.styles.filter(style => !style.source);
+  withDefaults.styles = sourcedStyles
+    .concat(addSources(unsourcedStyles, 'cold'))
+    .concat(addSources(unsourcedStyles, 'hot'));
 
   return withDefaults;
 }

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -231,4 +231,79 @@ test('Options test', async (t) => {
 
     assert.deepEqual(styles, Draw.options.styles);
   });
+
+  await t.test('custom styles with existing source are not duplicated', () => {
+    const Draw = new MapboxDraw({styles: [{
+      'id': 'custom-source-layer',
+      'source': 'my-custom-source',
+      'type': 'fill',
+      'filter': ['all', ['==', '$type', 'Polygon']],
+      'paint': {
+        'fill-color': '#fff'
+      }
+    }]});
+
+    const styles = [{
+      'id': 'custom-source-layer',
+      'source': 'my-custom-source',
+      'type': 'fill',
+      'filter': ['all', ['==', '$type', 'Polygon']],
+      'paint': {
+        'fill-color': '#fff'
+      }
+    }];
+
+    assert.deepEqual(styles, Draw.options.styles);
+  });
+
+  await t.test('custom styles with mixed sourced and unsourced styles', () => {
+    const Draw = new MapboxDraw({styles: [{
+      'id': 'custom-source-layer',
+      'source': 'my-custom-source',
+      'type': 'fill',
+      'filter': ['all', ['==', '$type', 'Polygon']],
+      'paint': {
+        'fill-color': '#fff'
+      }
+    }, {
+      'id': 'custom-point',
+      'type': 'circle',
+      'filter': ['all', ['==', '$type', 'Point']],
+      'paint': {
+        'circle-color': '#fff'
+      }
+    }]});
+
+    const styles = [
+      {
+        'id': 'custom-source-layer',
+        'source': 'my-custom-source',
+        'type': 'fill',
+        'filter': ['all', ['==', '$type', 'Polygon']],
+        'paint': {
+          'fill-color': '#fff'
+        }
+      },
+      {
+        'id': 'custom-point.cold',
+        'source': 'mapbox-gl-draw-cold',
+        'type': 'circle',
+        'filter': ['all', ['==', '$type', 'Point']],
+        'paint': {
+          'circle-color': '#fff'
+        }
+      },
+      {
+        'id': 'custom-point.hot',
+        'source': 'mapbox-gl-draw-hot',
+        'type': 'circle',
+        'filter': ['all', ['==', '$type', 'Point']],
+        'paint': {
+          'circle-color': '#fff'
+        }
+      }
+    ];
+
+    assert.deepEqual(styles, Draw.options.styles);
+  });
 });


### PR DESCRIPTION
This PR fixes an issue in options.js where styles with a predefined source were added twice, producing duplicate layers with the same id. That breaks Mapbox GL because layer IDs must be unique.
Now, styles that already define a source are kept once, and only styles without a source are duplicated for cold and hot.
Why
When a style already has a source, it should not be duplicated. The previous behavior created duplicate layer IDs and caused errors for users who define their own source.