### PR TITLE
fix: ensure feature is sorted by area (asc)

### DIFF
--- a/src/lib/sort_features.js
+++ b/src/lib/sort_features.js
@@ -33,11 +33,7 @@ function comparator(a, b) {
 function sortFeatures(features) {
   return features.map((feature) => {
     if (feature.geometry.type === Constants.geojsonTypes.POLYGON) {
-      feature.area = area.geometry({
-        type: Constants.geojsonTypes.FEATURE,
-        property: {},
-        geometry: feature.geometry
-      });
+      feature.area = area.geometry(feature.geometry);
     }
     return feature;
   }).sort(comparator).map((feature) => {

--- a/test/sort_features.test.js
+++ b/test/sort_features.test.js
@@ -9,10 +9,10 @@ test('sortFeatures', () => {
       properties: { id: 1 }
     },
     {
-      id: 'medium-polygon',
+      id: 'huge-polygon',
       geometry: {
         type: 'Polygon',
-        coordinates: [[[15, 50], [15, 59], [35, 59], [35, 50], [15, 50]]]
+        coordinates: [[[58, 27], [58, 68], [101, 68], [101, 27], [58, 27]]]
       }
     },
     {
@@ -20,10 +20,10 @@ test('sortFeatures', () => {
       properties: { id: 3 }
     },
     {
-      id: 'huge-polygon',
+      id: 'medium-polygon',
       geometry: {
         type: 'Polygon',
-        coordinates: [[[58, 27], [58, 68], [101, 68], [101, 27], [58, 27]]]
+        coordinates: [[[15, 50], [15, 59], [35, 59], [35, 50], [15, 50]]]
       }
     },
     {


### PR DESCRIPTION
**Fixes** https://github.com/mapbox/mapbox-gl-draw/issues/1540

When multiple polygons overlap, clicking on a smaller polygon could select the larger polygon instead. The `sortFeatures` function was intended to sort polygons by area (smallest first), but `area.geometry()` was being called with a GeoJSON Feature wrapper instead of the raw geometry object. This was causing the area result to be always undefined and the sorting logic to fail.

This PR fixes the area calculation by passing `feature.geometry` directly, and swaps the polygon input order in the existing test so it no longer passes by coincidence. Previously, the test input was already in the expected order, so the broken sort still produced a green result.

**Before fix:**

https://github.com/user-attachments/assets/442500bf-eb50-4bd1-b62b-f711e7331781



**After fix:**


https://github.com/user-attachments/assets/4371961b-00eb-4222-a72f-a92990677d56


